### PR TITLE
0.7.4

### DIFF
--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -21,7 +21,7 @@ namespace ArktoonShaders
         MaterialProperty BaseColor;
         MaterialProperty Normalmap;
         MaterialProperty BumpScale;
-        MaterialProperty Emissionmap;
+        MaterialProperty EmissionMap;
         MaterialProperty EmissionColor;
         MaterialProperty ShadowborderMin;
         MaterialProperty ShadowborderMax;
@@ -94,9 +94,9 @@ namespace ArktoonShaders
             // FindProperties
             BaseTexture = FindProperty("_MainTex", props);
             BaseColor = FindProperty("_Color", props);
-            Normalmap = FindProperty("_Normalmap", props);
+            Normalmap = FindProperty("_BumpMap", props);
             BumpScale = FindProperty("_BumpScale", props);
-            Emissionmap = FindProperty("_Emissionmap", props);
+            EmissionMap = FindProperty("_EmissionMap", props);
             EmissionColor = FindProperty("_EmissionColor", props);
             if(isCutout) CutoutCutoutAdjust = FindProperty("_CutoutCutoutAdjust", props);
             ShadowborderMin = FindProperty("_ShadowborderMin", props);
@@ -164,7 +164,7 @@ namespace ArktoonShaders
                     EditorGUI.indentLevel ++;
                     materialEditor.TexturePropertySingleLine(new GUIContent("Main Texture", "Base Color Texture (RGB)"), BaseTexture, BaseColor);
                     materialEditor.TexturePropertySingleLine(new GUIContent("Normal Map", "Normal Map (RGB)"), Normalmap, BumpScale);
-                    materialEditor.TexturePropertySingleLine(new GUIContent("Emission", "Emission (RGB)"), Emissionmap, EmissionColor);
+                    materialEditor.TexturePropertySingleLine(new GUIContent("Emission", "Emission (RGB)"), EmissionMap, EmissionColor);
                     EditorGUI.indentLevel --;
                 }
 

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -20,6 +20,7 @@ namespace ArktoonShaders
         MaterialProperty BaseTexture;
         MaterialProperty BaseColor;
         MaterialProperty Normalmap;
+        MaterialProperty BumpScale;
         MaterialProperty Emissionmap;
         MaterialProperty EmissionColor;
         MaterialProperty ShadowborderMin;
@@ -94,6 +95,7 @@ namespace ArktoonShaders
             BaseTexture = FindProperty("_MainTex", props);
             BaseColor = FindProperty("_Color", props);
             Normalmap = FindProperty("_Normalmap", props);
+            BumpScale = FindProperty("_BumpScale", props);
             Emissionmap = FindProperty("_Emissionmap", props);
             EmissionColor = FindProperty("_EmissionColor", props);
             if(isCutout) CutoutCutoutAdjust = FindProperty("_CutoutCutoutAdjust", props);
@@ -161,7 +163,7 @@ namespace ArktoonShaders
                 {
                     EditorGUI.indentLevel ++;
                     materialEditor.TexturePropertySingleLine(new GUIContent("Main Texture", "Base Color Texture (RGB)"), BaseTexture, BaseColor);
-                    materialEditor.TexturePropertySingleLine(new GUIContent("Normal Map", "Normal Map (RGB)"), Normalmap);
+                    materialEditor.TexturePropertySingleLine(new GUIContent("Normal Map", "Normal Map (RGB)"), Normalmap, BumpScale);
                     materialEditor.TexturePropertySingleLine(new GUIContent("Emission", "Emission (RGB)"), Emissionmap, EmissionColor);
                     EditorGUI.indentLevel --;
                 }

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -50,6 +50,7 @@ namespace ArktoonShaders
         MaterialProperty OutlineColor;
         MaterialProperty OutlineTextureColorRate;
         MaterialProperty UseMatcap;
+        MaterialProperty MatcapBlendMode;
         MaterialProperty MatcapBlend;
         MaterialProperty MatcapTexture;
         MaterialProperty MatcapColor;
@@ -72,6 +73,7 @@ namespace ArktoonShaders
         MaterialProperty RimTexture;
         MaterialProperty RimUseBaseTexture;
         MaterialProperty UseShadowCap;
+        MaterialProperty ShadowCapBlendMode;
         MaterialProperty ShadowCapBlend;
         MaterialProperty ShadowCapBlendMask;
         MaterialProperty ShadowCapNormalMix;
@@ -125,6 +127,7 @@ namespace ArktoonShaders
             if(isOpaque || isCutout) OutlineColor = FindProperty("_OutlineColor", props);
             if(isOpaque || isCutout) OutlineTextureColorRate = FindProperty("_OutlineTextureColorRate", props);
             UseMatcap = FindProperty("_UseMatcap", props);
+            MatcapBlendMode = FindProperty("_MatcapBlendMode", props);
             MatcapBlend = FindProperty("_MatcapBlend", props);
             MatcapTexture = FindProperty("_MatcapTexture", props);
             MatcapColor = FindProperty("_MatcapColor", props);
@@ -147,6 +150,7 @@ namespace ArktoonShaders
             RimTexture = FindProperty("_RimTexture", props);
             RimUseBaseTexture = FindProperty("_RimUseBaseTexture", props);
             UseShadowCap = FindProperty("_UseShadowCap", props);
+            ShadowCapBlendMode = FindProperty("_ShadowCapBlendMode", props);
             ShadowCapBlend = FindProperty("_ShadowCapBlend", props);
             ShadowCapBlendMask = FindProperty("_ShadowCapBlendMask", props);
             ShadowCapNormalMix = FindProperty("_ShadowCapNormalMix", props);
@@ -259,6 +263,8 @@ namespace ArktoonShaders
                     var useMatcap = UseMatcap.floatValue;
                     if(useMatcap > 0)
                     {
+
+                        materialEditor.ShaderProperty(MatcapBlendMode,"Blend Mode");
                         materialEditor.ShaderProperty(MatcapBlend,"Blend");
                         materialEditor.ShaderProperty(MatcapBlendMask,"Blend Mask");
                         materialEditor.ShaderProperty(MatcapNormalMix, "Normal Map mix");
@@ -314,6 +320,7 @@ namespace ArktoonShaders
                     var useShadowCap = UseShadowCap.floatValue;
                     if(useShadowCap > 0)
                     {
+                        materialEditor.ShaderProperty(ShadowCapBlendMode,"Blend Mode");
                         materialEditor.ShaderProperty(ShadowCapBlend,"Blend");
                         materialEditor.ShaderProperty(ShadowCapBlendMask,"Blend Mask");
                         materialEditor.ShaderProperty(ShadowCapNormalMix,"Normal Map mix");

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -25,6 +25,8 @@ namespace ArktoonShaders
         MaterialProperty ShadowborderMin;
         MaterialProperty ShadowborderMax;
         MaterialProperty ShadowStrength;
+        MaterialProperty ShadowUseStep;
+        MaterialProperty ShadowSteps;
         MaterialProperty PointShadowStrength;
         MaterialProperty ShadowStrengthMask;
         MaterialProperty CutoutCutoutAdjust;
@@ -98,6 +100,8 @@ namespace ArktoonShaders
             ShadowborderMin = FindProperty("_ShadowborderMin", props);
             ShadowborderMax = FindProperty("_ShadowborderMax", props);
             ShadowStrength = FindProperty("_ShadowStrength", props);
+            ShadowUseStep = FindProperty("_ShadowUseStep", props);
+            ShadowSteps = FindProperty("_ShadowSteps", props);
             PointShadowStrength = FindProperty("_PointShadowStrength", props);
             ShadowStrengthMask = FindProperty("_ShadowStrengthMask", props);
             ShadowPlanBUsePlanB = FindProperty("_ShadowPlanBUsePlanB", props);
@@ -180,6 +184,13 @@ namespace ArktoonShaders
                     materialEditor.ShaderProperty(ShadowborderMax, "Shadow border Begin");
                     materialEditor.ShaderProperty(ShadowStrength, "Shadow Strength");
                     materialEditor.ShaderProperty(ShadowStrengthMask, "Shadow Strength Mask");
+                    materialEditor.ShaderProperty(ShadowUseStep, "Use Shadow Steps");
+                    var useStep = ShadowUseStep.floatValue;
+                    if(useStep > 0)
+                    {
+                        materialEditor.ShaderProperty(ShadowSteps, " ");
+                    }
+
                     materialEditor.ShaderProperty(ShadowPlanBUsePlanB, "Use Custom Shade");
                     var usePlanB = ShadowPlanBUsePlanB.floatValue;
                     if(usePlanB > 0)
@@ -314,9 +325,14 @@ namespace ArktoonShaders
                 EditorGUILayout.LabelField("Advanced", EditorStyles.boldLabel);
                 {
                     EditorGUI.indentLevel ++;
-                    materialEditor.ShaderProperty(PointShadowStrength, "[exp] Point Shadow Str.");
                     materialEditor.ShaderProperty(Cull, "Cull");
                     if(isFade) materialEditor.ShaderProperty(ZWrite, "ZWrite");
+                    EditorGUILayout.LabelField("PointLight Shadows", EditorStyles.boldLabel);
+                    {
+                        EditorGUI.indentLevel ++;
+                        materialEditor.ShaderProperty(PointShadowStrength, "Strength");
+                        EditorGUI.indentLevel --;
+                    }
                     EditorGUI.indentLevel --;
                 }
             }

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -21,6 +21,9 @@ Shader "arktoon/AlphaCutout" {
         _ShadowborderMax ("[Shadow] border Max", Range(0, 1)) = 0.55
         _ShadowStrength ("[Shadow] Strength", Range(0, 1)) = 0.5
         _ShadowStrengthMask ("[Shadow] Strength Mask", 2D) = "white" {}
+        // Shadow steps
+        [Toggle(USE_SHADOW_STEPS)]_ShadowUseStep ("[Shadow] use step", Float ) = 0
+        _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
         // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
         _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.25
         // Plan B
@@ -97,6 +100,7 @@ Shader "arktoon/AlphaCutout" {
             #pragma shader_feature USE_RIM
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
+            #pragma shader_feature USE_SHADOW_STEPS
 
             #pragma vertex vert
             #pragma fragment frag
@@ -119,6 +123,7 @@ Shader "arktoon/AlphaCutout" {
             uniform float _ShadowborderMin;
             uniform float _ShadowborderMax;
             uniform float _ShadowStrength;
+            uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
@@ -195,7 +200,13 @@ Shader "arktoon/AlphaCutout" {
                 float lightDifference = ((topIndirectLighting+grayscalelightcolor)-bottomIndirectLighting);
                 float remappedLight = ((grayscaleDirectLighting-bottomIndirectLighting)/lightDifference);
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))) * _ShadowStrengthMask_var * _ShadowStrength);
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))));
+
+                #ifdef USE_SHADOW_STEPS
+                    directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
+                #endif
+
+                directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * _ShadowStrength;
 
                 // 頂点ライティングを処理
 				float3 lightContribution = lerp(i.ambient, i.ambientAtten, 1-_PointShadowStrength);

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -12,6 +12,7 @@ Shader "arktoon/AlphaCutout" {
         _MainTex ("[Common] Base Texture", 2D) = "white" {}
         _Color ("[Common] Base Color", Color) = (1,1,1,1)
         _Normalmap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
         _Emissionmap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Cutout
@@ -127,6 +128,7 @@ Shader "arktoon/AlphaCutout" {
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform float _BumpScale;
             uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
             uniform float4 _EmissionColor;
             uniform sampler2D _MatcapTexture; uniform float4 _MatcapTexture_ST;
@@ -164,7 +166,7 @@ Shader "arktoon/AlphaCutout" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)));
+                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
                 float3 normalLocal = _Normalmap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
                 float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
@@ -309,6 +311,7 @@ Shader "arktoon/AlphaCutout" {
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform float _BumpScale;
             uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
             uniform float4 _EmissionColor;
 
@@ -366,7 +369,7 @@ Shader "arktoon/AlphaCutout" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)));
+                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
                 float3 normalLocal = _Normalmap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -11,9 +11,9 @@ Shader "arktoon/AlphaCutout" {
         // Common
         _MainTex ("[Common] Base Texture", 2D) = "white" {}
         _Color ("[Common] Base Color", Color) = (1,1,1,1)
-        _Normalmap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpMap ("[Common] Normal map", 2D) = "bump" {}
         _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
-        _Emissionmap ("[Common] Emission map", 2D) = "white" {}
+        _EmissionMap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Cutout
         _CutoutCutoutAdjust ("Cutout Border Adjust", Range(0, 1)) = 0.5
@@ -127,9 +127,9 @@ Shader "arktoon/AlphaCutout" {
             uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
-            uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
             uniform float _BumpScale;
-            uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
+            uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
             uniform float4 _EmissionColor;
             uniform sampler2D _MatcapTexture; uniform float4 _MatcapTexture_ST;
             uniform float _MatcapBlend;
@@ -166,8 +166,8 @@ Shader "arktoon/AlphaCutout" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
-                float3 normalLocal = _Normalmap_var.rgb;
+                float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+                float3 normalLocal = _BumpMap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
                 float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
                 float3 lightColor = _LightColor0.rgb;
@@ -271,8 +271,8 @@ Shader "arktoon/AlphaCutout" {
                     float3 RimLight = float3(0,0,0);
                 #endif
 
-                float4 _Emissionmap_var = tex2D(_Emissionmap,TRANSFORM_TEX(i.uv0, _Emissionmap));
-                float3 emissive = max(((_Emissionmap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
+                float4 _EmissionMap_var = tex2D(_EmissionMap,TRANSFORM_TEX(i.uv0, _EmissionMap));
+                float3 emissive = max(((_EmissionMap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
                 float3 finalColor = emissive + min(max((ToonedMap+ReflectionMap),Gloss),shadowcap);
                 fixed4 finalRGBA = fixed4(finalColor,1);
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
@@ -310,9 +310,9 @@ Shader "arktoon/AlphaCutout" {
             uniform float _CutoutCutoutAdjust;
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
-            uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
             uniform float _BumpScale;
-            uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
+            uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
             uniform float4 _EmissionColor;
 
             uniform float _RimFresnelPower;
@@ -369,8 +369,8 @@ Shader "arktoon/AlphaCutout" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
-                float3 normalLocal = _Normalmap_var.rgb;
+                float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+                float3 normalLocal = _BumpMap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -13,6 +13,7 @@ Shader "arktoon/Fade" {
         _MainTex ("[Common] Base Texture", 2D) = "white" {}
         _Color ("[Common] Base Color", Color) = (1,1,1,1)
         _Normalmap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
         _Emissionmap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
@@ -122,6 +123,7 @@ Shader "arktoon/Fade" {
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform float _BumpScale;
             uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
             uniform float4 _EmissionColor;
             uniform sampler2D _MatcapTexture; uniform float4 _MatcapTexture_ST;
@@ -159,7 +161,7 @@ Shader "arktoon/Fade" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)));
+                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
                 float3 normalLocal = _Normalmap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
                 float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
@@ -304,6 +306,7 @@ Shader "arktoon/Fade" {
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform float _BumpScale;
             uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
             uniform float4 _EmissionColor;
 
@@ -361,7 +364,7 @@ Shader "arktoon/Fade" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)));
+                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
                 float3 normalLocal = _Normalmap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -43,6 +43,7 @@ Shader "arktoon/Fade" {
         _GlossColor ("[Gloss] Color", Color) = (1,1,1,1)
         // MatCap
         [Toggle(USE_MATCAP)]_UseMatcap ("[MatCap] Enabled", Float) = 0
+        [KeywordEnum(Add, Lighten, Screen)] _MatcapBlendMode ("[MatCap] Blend Mode", Float) = 0
         _MatcapBlend ("[MatCap] Blend", Range(0, 3)) = 1
         _MatcapBlendMask ("[MatCap] Blend Mask", 2D) = "white" {}
         _MatcapNormalMix ("[MatCap] Normal map mix", Range(0, 2)) = 1
@@ -68,6 +69,7 @@ Shader "arktoon/Fade" {
         [MaterialToggle] _RimUseBaseTexture ("[Rim] Use Base Texture", Float ) = 0
         // ShadowCap
         [Toggle(USE_SHADOWCAP)]_UseShadowCap ("[ShadowCap] Enabled", Float) = 0
+        [KeywordEnum(Darken, Multiply)] _ShadowCapBlendMode ("[ShadowCap] Blend Mode", Float) = 0
         _ShadowCapBlend ("[ShadowCap] Blend", Range(0, 3)) = 1
         _ShadowCapBlendMask ("[ShadowCap] Blend Mask", 2D) = "white" {}
         _ShadowCapNormalMix ("[ShadowCap] Normal map mix", Range(0, 2)) = 1
@@ -98,6 +100,8 @@ Shader "arktoon/Fade" {
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
             #pragma shader_feature USE_SHADOW_STEPS
+            #pragma multi_compile _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
+            #pragma multi_compile _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY
 
             #pragma vertex vert
             #pragma fragment frag
@@ -267,8 +271,30 @@ Shader "arktoon/Fade" {
                 #endif
 
                 float4 _EmissionMap_var = tex2D(_EmissionMap,TRANSFORM_TEX(i.uv0, _EmissionMap));
-                float3 emissive = max(((_EmissionMap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
-                float3 finalColor = emissive + min(max((ToonedMap+ReflectionMap),Gloss),shadowcap);
+                float3 emissive = max((_EmissionMap_var.rgb*_EmissionColor.rgb),RimLight);
+                float3 finalcolor2 = max((ToonedMap+ReflectionMap),Gloss);
+
+                // ShadeCapのブレンドモード
+                #ifdef USE_SHADOWCAP
+                    #ifdef _SHADOWCAPBLENDMODE_DARKEN
+                        finalcolor2 = min(finalcolor2, shadowcap);
+                    #elif _SHADOWCAPBLENDMODE_MULTIPLY
+                        finalcolor2 = finalcolor2 * shadowcap;
+                    #endif
+                #endif
+
+                // MatCapのブレンドモード
+                #ifdef USE_MATCAP
+                    #ifdef _MATCAPBLENDMODE_LIGHTEN
+                        finalcolor2 = max(finalcolor2, matcap);
+                    #elif _MATCAPBLENDMODE_ADD
+                        finalcolor2 = finalcolor2 + matcap;
+                    #elif _MATCAPBLENDMODE_SCREEN
+                        finalcolor2 = 1-(1-finalcolor2) * (1-matcap);
+                    #endif
+                #endif
+
+                float3 finalColor = emissive + finalcolor2;
                 fixed4 finalRGBA = fixed4(finalColor,(_MainTex_var.a*_Color.a));
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
                 return finalRGBA;
@@ -289,6 +315,9 @@ Shader "arktoon/Fade" {
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_RIM
             #pragma shader_feature USE_MATCAP
+            #pragma multi_compile _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_SCREEN
+            #pragma multi_compile _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY
+
             #pragma vertex vert
             #pragma fragment frag
             #include "UnityCG.cginc"
@@ -420,7 +449,27 @@ Shader "arktoon/Fade" {
                 #endif
 
                 float3 ToonedMap = Diffuse * coloredLight;
-                float3 finalColor = matcap + min(max((max(ToonedMap, RimLight)),Gloss),shadowcap);
+                float3 finalColor = max((max(ToonedMap, RimLight)),Gloss);
+
+                // ShadeCapのブレンドモード
+                #ifdef USE_SHADOWCAP
+                    #ifdef _SHADOWCAPBLENDMODE_DARKEN
+                        finalColor = min(finalColor, shadowcap);
+                    #elif _SHADOWCAPBLENDMODE_MULTIPLY
+                        finalColor = finalColor * shadowcap;
+                    #endif
+                #endif
+
+                // MatCapのブレンドモード
+                #ifdef USE_MATCAP
+                    #ifdef _MATCAPBLENDMODE_LIGHTEN
+                        finalColor = max(finalColor, matcap);
+                    #elif _MATCAPBLENDMODE_ADD
+                        finalColor = finalColor + matcap;
+                    #elif _MATCAPBLENDMODE_SCREEN
+                        finalColor = 1-(1-finalColor) * (1-matcap);
+                    #endif
+                #endif
 
                 fixed4 finalRGBA = fixed4(finalColor * (_MainTex_var.a * _Color.a),0);
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -12,9 +12,9 @@ Shader "arktoon/Fade" {
         // Common
         _MainTex ("[Common] Base Texture", 2D) = "white" {}
         _Color ("[Common] Base Color", Color) = (1,1,1,1)
-        _Normalmap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpMap ("[Common] Normal map", 2D) = "bump" {}
         _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
-        _Emissionmap ("[Common] Emission map", 2D) = "white" {}
+        _EmissionMap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
         _ShadowborderMin ("[Shadow] border Min", Range(0, 1)) = 0.499
@@ -122,9 +122,9 @@ Shader "arktoon/Fade" {
             uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
-            uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
             uniform float _BumpScale;
-            uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
+            uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
             uniform float4 _EmissionColor;
             uniform sampler2D _MatcapTexture; uniform float4 _MatcapTexture_ST;
             uniform float _MatcapBlend;
@@ -161,8 +161,8 @@ Shader "arktoon/Fade" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
-                float3 normalLocal = _Normalmap_var.rgb;
+                float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+                float3 normalLocal = _BumpMap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
                 float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
                 float3 lightColor = _LightColor0.rgb;
@@ -266,8 +266,8 @@ Shader "arktoon/Fade" {
                     float3 RimLight = float3(0,0,0);
                 #endif
 
-                float4 _Emissionmap_var = tex2D(_Emissionmap,TRANSFORM_TEX(i.uv0, _Emissionmap));
-                float3 emissive = max(((_Emissionmap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
+                float4 _EmissionMap_var = tex2D(_EmissionMap,TRANSFORM_TEX(i.uv0, _EmissionMap));
+                float3 emissive = max(((_EmissionMap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
                 float3 finalColor = emissive + min(max((ToonedMap+ReflectionMap),Gloss),shadowcap);
                 fixed4 finalRGBA = fixed4(finalColor,(_MainTex_var.a*_Color.a));
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
@@ -305,9 +305,9 @@ Shader "arktoon/Fade" {
 
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
-            uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
             uniform float _BumpScale;
-            uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
+            uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
             uniform float4 _EmissionColor;
 
             uniform float _RimFresnelPower;
@@ -364,8 +364,8 @@ Shader "arktoon/Fade" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
-                float3 normalLocal = _Normalmap_var.rgb;
+                float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+                float3 normalLocal = _BumpMap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -20,6 +20,9 @@ Shader "arktoon/Fade" {
         _ShadowborderMax ("[Shadow] border Max", Range(0, 1)) = 0.55
         _ShadowStrength ("[Shadow] Strength", Range(0, 1)) = 0.5
         _ShadowStrengthMask ("[Shadow] Strength Mask", 2D) = "white" {}
+        // Shadow steps
+        [Toggle(USE_SHADOW_STEPS)]_ShadowUseStep ("[Shadow] use step", Float ) = 0
+        _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
         // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
         _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.25
         // Plan B
@@ -93,6 +96,7 @@ Shader "arktoon/Fade" {
             #pragma shader_feature USE_RIM
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
+            #pragma shader_feature USE_SHADOW_STEPS
 
             #pragma vertex vert
             #pragma fragment frag
@@ -114,6 +118,7 @@ Shader "arktoon/Fade" {
             uniform float _ShadowborderMin;
             uniform float _ShadowborderMax;
             uniform float _ShadowStrength;
+            uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
@@ -190,7 +195,13 @@ Shader "arktoon/Fade" {
                 float lightDifference = ((topIndirectLighting+grayscalelightcolor)-bottomIndirectLighting);
                 float remappedLight = ((grayscaleDirectLighting-bottomIndirectLighting)/lightDifference);
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))) * _ShadowStrengthMask_var * _ShadowStrength);
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))));
+
+                #ifdef USE_SHADOW_STEPS
+                    directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
+                #endif
+
+                directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * _ShadowStrength;
 
                 // 頂点ライティングを処理
 				float3 lightContribution = lerp(i.ambient, i.ambientAtten, 1-_PointShadowStrength);

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -14,6 +14,7 @@ Shader "arktoon/Opaque" {
         _MainTex ("[Common] Base Texture", 2D) = "white" {}
         _Color ("[Common] Base Color", Color) = (1,1,1,1)
         _Normalmap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
         _Emissionmap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
@@ -128,6 +129,7 @@ Shader "arktoon/Opaque" {
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform float _BumpScale;
             uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
             uniform float4 _EmissionColor;
             uniform sampler2D _MatcapTexture; uniform float4 _MatcapTexture_ST;
@@ -165,7 +167,7 @@ Shader "arktoon/Opaque" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)));
+                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
                 float3 normalLocal = _Normalmap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
                 float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
@@ -309,6 +311,7 @@ Shader "arktoon/Opaque" {
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
             uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform float _BumpScale;
             uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
             uniform float4 _EmissionColor;
 
@@ -366,7 +369,7 @@ Shader "arktoon/Opaque" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)));
+                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
                 float3 normalLocal = _Normalmap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -52,6 +52,7 @@ Shader "arktoon/Opaque" {
         _OutlineTextureColorRate ("[Outline] Texture Color Rate", Range(0, 1)) = 0.05
         // MatCap
         [Toggle(USE_MATCAP)]_UseMatcap ("[MatCap] Enabled", Float) = 0
+        [KeywordEnum(Add, Lighten, Screen)] _MatcapBlendMode ("[MatCap] Blend Mode", Float) = 0
         _MatcapBlend ("[MatCap] Blend", Range(0, 3)) = 1
         _MatcapBlendMask ("[MatCap] Blend Mask", 2D) = "white" {}
         _MatcapNormalMix ("[MatCap] Normal map mix", Range(0, 2)) = 1
@@ -77,6 +78,7 @@ Shader "arktoon/Opaque" {
         [MaterialToggle] _RimUseBaseTexture ("[Rim] Use Base Texture", Float ) = 0
         // ShadowCap
         [Toggle(USE_SHADOWCAP)]_UseShadowCap ("[ShadowCap] Enabled", Float) = 0
+        [KeywordEnum(Darken, Multiply)] _ShadowCapBlendMode ("[ShadowCap] Blend Mode", Float) = 0
         _ShadowCapBlend ("[ShadowCap] Blend", Range(0, 3)) = 1
         _ShadowCapBlendMask ("[ShadowCap] Blend Mask", 2D) = "white" {}
         _ShadowCapNormalMix ("[ShadowCap] Normal map mix", Range(0, 2)) = 1
@@ -104,6 +106,8 @@ Shader "arktoon/Opaque" {
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
             #pragma shader_feature USE_SHADOW_STEPS
+            #pragma multi_compile _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
+            #pragma multi_compile _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY
 
             #pragma vertex vert
             #pragma fragment frag
@@ -273,8 +277,30 @@ Shader "arktoon/Opaque" {
                 #endif
 
                 float4 _EmissionMap_var = tex2D(_EmissionMap,TRANSFORM_TEX(i.uv0, _EmissionMap));
-                float3 emissive = max(((_EmissionMap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
-                float3 finalColor = emissive + min(max((ToonedMap+ReflectionMap),Gloss),shadowcap);
+                float3 emissive = max((_EmissionMap_var.rgb*_EmissionColor.rgb),RimLight);
+                float3 finalcolor2 = max((ToonedMap+ReflectionMap),Gloss);
+
+                // ShadeCapのブレンドモード
+                #ifdef USE_SHADOWCAP
+                    #ifdef _SHADOWCAPBLENDMODE_DARKEN
+                        finalcolor2 = min(finalcolor2, shadowcap);
+                    #elif _SHADOWCAPBLENDMODE_MULTIPLY
+                        finalcolor2 = finalcolor2 * shadowcap;
+                    #endif
+                #endif
+
+                // MatCapのブレンドモード
+                #ifdef USE_MATCAP
+                    #ifdef _MATCAPBLENDMODE_LIGHTEN
+                        finalcolor2 = max(finalcolor2, matcap);
+                    #elif _MATCAPBLENDMODE_ADD
+                        finalcolor2 = finalcolor2 + matcap;
+                    #elif _MATCAPBLENDMODE_SCREEN
+                        finalcolor2 = 1-(1-finalcolor2) * (1-matcap);
+                    #endif
+                #endif
+
+                float3 finalColor = emissive + finalcolor2;
                 fixed4 finalRGBA = fixed4(finalColor,1);
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
                 return finalRGBA;
@@ -294,6 +320,9 @@ Shader "arktoon/Opaque" {
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_RIM
             #pragma shader_feature USE_MATCAP
+            #pragma multi_compile _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_SCREEN
+            #pragma multi_compile _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY
+
             #pragma vertex vert
             #pragma fragment frag
             #include "UnityCG.cginc"
@@ -425,7 +454,27 @@ Shader "arktoon/Opaque" {
                 #endif
 
                 float3 ToonedMap = Diffuse * coloredLight;
-                float3 finalColor = matcap + min(max((max(ToonedMap, RimLight)),Gloss),shadowcap);
+                float3 finalColor = max((max(ToonedMap, RimLight)),Gloss);
+
+                // ShadeCapのブレンドモード
+                #ifdef USE_SHADOWCAP
+                    #ifdef _SHADOWCAPBLENDMODE_DARKEN
+                        finalColor = min(finalColor, shadowcap);
+                    #elif _SHADOWCAPBLENDMODE_MULTIPLY
+                        finalColor = finalColor * shadowcap;
+                    #endif
+                #endif
+
+                // MatCapのブレンドモード
+                #ifdef USE_MATCAP
+                    #ifdef _MATCAPBLENDMODE_LIGHTEN
+                        finalColor = max(finalColor, matcap);
+                    #elif _MATCAPBLENDMODE_ADD
+                        finalColor = finalColor + matcap;
+                    #elif _MATCAPBLENDMODE_SCREEN
+                        finalColor = 1-(1-finalColor) * (1-matcap);
+                    #endif
+                #endif
 
                 fixed4 finalRGBA = fixed4(finalColor * 1,0);
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -13,9 +13,9 @@ Shader "arktoon/Opaque" {
         // Common
         _MainTex ("[Common] Base Texture", 2D) = "white" {}
         _Color ("[Common] Base Color", Color) = (1,1,1,1)
-        _Normalmap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpMap ("[Common] Normal map", 2D) = "bump" {}
         _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
-        _Emissionmap ("[Common] Emission map", 2D) = "white" {}
+        _EmissionMap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
         _ShadowborderMin ("[Shadow] border Min", Range(0, 1)) = 0.499
@@ -128,9 +128,9 @@ Shader "arktoon/Opaque" {
             uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
-            uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
             uniform float _BumpScale;
-            uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
+            uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
             uniform float4 _EmissionColor;
             uniform sampler2D _MatcapTexture; uniform float4 _MatcapTexture_ST;
             uniform float _MatcapBlend;
@@ -167,8 +167,8 @@ Shader "arktoon/Opaque" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
-                float3 normalLocal = _Normalmap_var.rgb;
+                float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+                float3 normalLocal = _BumpMap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
                 float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
                 float3 lightColor = _LightColor0.rgb;
@@ -272,8 +272,8 @@ Shader "arktoon/Opaque" {
                     float3 RimLight = float3(0,0,0);
                 #endif
 
-                float4 _Emissionmap_var = tex2D(_Emissionmap,TRANSFORM_TEX(i.uv0, _Emissionmap));
-                float3 emissive = max(((_Emissionmap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
+                float4 _EmissionMap_var = tex2D(_EmissionMap,TRANSFORM_TEX(i.uv0, _EmissionMap));
+                float3 emissive = max(((_EmissionMap_var.rgb*_EmissionColor.rgb)+matcap),RimLight);
                 float3 finalColor = emissive + min(max((ToonedMap+ReflectionMap),Gloss),shadowcap);
                 fixed4 finalRGBA = fixed4(finalColor,1);
                 UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
@@ -310,9 +310,9 @@ Shader "arktoon/Opaque" {
 
             uniform float _PointShadowStrength;
             uniform sampler2D _ShadowStrengthMask; uniform float4 _ShadowStrengthMask_ST;
-            uniform sampler2D _Normalmap; uniform float4 _Normalmap_ST;
+            uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
             uniform float _BumpScale;
-            uniform sampler2D _Emissionmap; uniform float4 _Emissionmap_ST;
+            uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
             uniform float4 _EmissionColor;
 
             uniform float _RimFresnelPower;
@@ -369,8 +369,8 @@ Shader "arktoon/Opaque" {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
                 float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-                float3 _Normalmap_var = UnpackScaleNormal(tex2D(_Normalmap,TRANSFORM_TEX(i.uv0, _Normalmap)), _BumpScale);
-                float3 normalLocal = _Normalmap_var.rgb;
+                float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+                float3 normalLocal = _BumpMap_var.rgb;
                 float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));


### PR DESCRIPTION
- MatCap, ShadeCapにブレンドモード実装 close #19
- （１パス：DirectionalLightおよびLightProbe）ポスタライズシャドウを設定できる機能
- Normalmapの内部名変更：Normalmap→BumpMap
（Standardに合わせてテクスチャを引き継げるように）
- 全体のNormalmapのかかり具合を設定できるスライダーを配置：BumpScale


