### PR TITLE
0.8 shadowexperimental

### DIFF
--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -40,8 +40,12 @@ namespace ArktoonShaders
         MaterialProperty ShadowPlanBCustomShadowTexture;
         MaterialProperty ShadowPlanBCustomShadowTextureRGB;
         MaterialProperty CustomShadow2nd;
-        MaterialProperty ShadowPlanB2borderMin;
-        MaterialProperty ShadowPlanB2borderMax;
+        MaterialProperty ShadowPlanB2border;
+        MaterialProperty ShadowPlanB2borderBlur;
+        MaterialProperty ShadowPlanB2HueShiftFromBase;
+        MaterialProperty ShadowPlanB2SaturationFromBase;
+        MaterialProperty ShadowPlanB2ValueFromBase;
+        MaterialProperty ShadowPlanB2UseCustomShadowTexture;
         MaterialProperty ShadowPlanB2CustomShadowTexture;
         MaterialProperty ShadowPlanB2CustomShadowTextureRGB;
         MaterialProperty UseGloss;
@@ -123,8 +127,13 @@ namespace ArktoonShaders
             ShadowPlanBCustomShadowTextureRGB = FindProperty("_ShadowPlanBCustomShadowTextureRGB", props);
 
             CustomShadow2nd = FindProperty("_CustomShadow2nd", props);
-            ShadowPlanB2borderMin = FindProperty("_ShadowPlanB2borderMin", props);
-            ShadowPlanB2borderMax = FindProperty("_ShadowPlanB2borderMax", props);
+
+            ShadowPlanB2border = FindProperty("_ShadowPlanB2border", props);
+            ShadowPlanB2borderBlur = FindProperty("_ShadowPlanB2borderBlur", props);
+            ShadowPlanB2HueShiftFromBase = FindProperty("_ShadowPlanB2HueShiftFromBase", props);
+            ShadowPlanB2SaturationFromBase = FindProperty("_ShadowPlanB2SaturationFromBase", props);
+            ShadowPlanB2ValueFromBase = FindProperty("_ShadowPlanB2ValueFromBase", props);
+            ShadowPlanB2UseCustomShadowTexture = FindProperty("_ShadowPlanB2UseCustomShadowTexture", props);
             ShadowPlanB2CustomShadowTexture = FindProperty("_ShadowPlanB2CustomShadowTexture", props);
             ShadowPlanB2CustomShadowTextureRGB = FindProperty("_ShadowPlanB2CustomShadowTextureRGB", props);
 
@@ -233,15 +242,24 @@ namespace ArktoonShaders
                             materialEditor.ShaderProperty(ShadowPlanBSaturationFromBase, "Saturation");
                             materialEditor.ShaderProperty(ShadowPlanBValueFromBase, "Value");
                         }
-                        materialEditor.ShaderProperty(CustomShadow2nd, "Use Shade2 Texture");
+                        materialEditor.ShaderProperty(CustomShadow2nd, "Use 2nd Shade ");
                         var customshadow2nd = CustomShadow2nd.floatValue;
                         if(customshadow2nd > 0)
                         {
                             EditorGUI.indentLevel ++;
-                            materialEditor.ShaderProperty(ShadowPlanB2borderMax, "Border End");
-                            materialEditor.ShaderProperty(ShadowPlanB2borderMin, "Border Begin");
-                            materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTexture,  "Shade Texture");
-                            materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTextureRGB,  "Shade Texture RGB");
+                            materialEditor.ShaderProperty(ShadowPlanB2border, "ShadowPlanB2border");
+                            materialEditor.ShaderProperty(ShadowPlanB2borderBlur, "ShadowPlanB2borderBlur");
+                            materialEditor.ShaderProperty(ShadowPlanB2UseCustomShadowTexture, "Use Shade Texture");
+                            var useShadeTexture2 = ShadowPlanB2UseCustomShadowTexture.floatValue;
+                            if(useShadeTexture2 > 0)
+                            {
+                                materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTexture,  "Shade Texture");
+                                materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTextureRGB,  "Shade Texture RGB");
+                            }else{
+                                materialEditor.ShaderProperty(ShadowPlanB2HueShiftFromBase, "ShadowPlanB2HueShiftFromBase");
+                                materialEditor.ShaderProperty(ShadowPlanB2SaturationFromBase, "ShadowPlanB2SaturationFromBase");
+                                materialEditor.ShaderProperty(ShadowPlanB2ValueFromBase, "ShadowPlanB2ValueFromBase");
+                            }
                             EditorGUI.indentLevel --;
                         }
                         EditorGUI.indentLevel --;

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -207,16 +207,16 @@ namespace ArktoonShaders
                 EditorGUILayout.LabelField("Shadow", EditorStyles.boldLabel);
                 {
                     EditorGUI.indentLevel ++;
-                    materialEditor.ShaderProperty(Shadowborder, "Shadow border");
-                    materialEditor.ShaderProperty(ShadowborderBlur, "Shadow border blur");
+                    materialEditor.ShaderProperty(Shadowborder, "Border pos");
+                    materialEditor.ShaderProperty(ShadowborderBlur, "Border blur");
                     if(ShadowPlanBUsePlanB.floatValue > 0)
                     {
-                        EditorGUILayout.LabelField("Shadow Strength (disabled)");
+                        EditorGUILayout.LabelField("Strength"," (disabled)", EditorStyles.centeredGreyMiniLabel);
                     } else {
-                        materialEditor.ShaderProperty(ShadowStrength, "Shadow Strength");
+                        materialEditor.ShaderProperty(ShadowStrength, "Strength");
                     }
-                    materialEditor.ShaderProperty(ShadowStrengthMask, "Shadow Strength Mask");
-                    materialEditor.ShaderProperty(ShadowUseStep, "Use Shadow Steps");
+                    materialEditor.ShaderProperty(ShadowStrengthMask, "Strength Mask");
+                    materialEditor.ShaderProperty(ShadowUseStep, "Use Steps");
                     var useStep = ShadowUseStep.floatValue;
                     if(useStep > 0)
                     {
@@ -227,8 +227,11 @@ namespace ArktoonShaders
                     var usePlanB = ShadowPlanBUsePlanB.floatValue;
                     if(usePlanB > 0)
                     {
+
                         EditorGUI.indentLevel ++;
-                        materialEditor.ShaderProperty(ShadowPlanBDefaultShadowMix, "Mix Default Shadow");
+                        materialEditor.ShaderProperty(ShadowPlanBDefaultShadowMix, "Mix Default Shade");
+                        EditorGUILayout.LabelField("1st shade", EditorStyles.boldLabel);
+                        EditorGUI.indentLevel ++;
                         materialEditor.ShaderProperty(ShadowPlanBUseCustomShadowTexture, "Use Shade Texture");
                         var useShadeTexture = ShadowPlanBUseCustomShadowTexture.floatValue;
                         if(useShadeTexture > 0)
@@ -242,13 +245,15 @@ namespace ArktoonShaders
                             materialEditor.ShaderProperty(ShadowPlanBSaturationFromBase, "Saturation");
                             materialEditor.ShaderProperty(ShadowPlanBValueFromBase, "Value");
                         }
-                        materialEditor.ShaderProperty(CustomShadow2nd, "Use 2nd Shade ");
+                        EditorGUI.indentLevel --;
+                        EditorGUILayout.LabelField("2nd shade", EditorStyles.boldLabel);
+                        EditorGUI.indentLevel ++;
+                        materialEditor.ShaderProperty(CustomShadow2nd, "Use");
                         var customshadow2nd = CustomShadow2nd.floatValue;
                         if(customshadow2nd > 0)
                         {
-                            EditorGUI.indentLevel ++;
-                            materialEditor.ShaderProperty(ShadowPlanB2border, "ShadowPlanB2border");
-                            materialEditor.ShaderProperty(ShadowPlanB2borderBlur, "ShadowPlanB2borderBlur");
+                            materialEditor.ShaderProperty(ShadowPlanB2border, "Border pos");
+                            materialEditor.ShaderProperty(ShadowPlanB2borderBlur, "Border blur");
                             materialEditor.ShaderProperty(ShadowPlanB2UseCustomShadowTexture, "Use Shade Texture");
                             var useShadeTexture2 = ShadowPlanB2UseCustomShadowTexture.floatValue;
                             if(useShadeTexture2 > 0)
@@ -256,12 +261,13 @@ namespace ArktoonShaders
                                 materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTexture,  "Shade Texture");
                                 materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTextureRGB,  "Shade Texture RGB");
                             }else{
-                                materialEditor.ShaderProperty(ShadowPlanB2HueShiftFromBase, "ShadowPlanB2HueShiftFromBase");
-                                materialEditor.ShaderProperty(ShadowPlanB2SaturationFromBase, "ShadowPlanB2SaturationFromBase");
-                                materialEditor.ShaderProperty(ShadowPlanB2ValueFromBase, "ShadowPlanB2ValueFromBase");
+                                materialEditor.ShaderProperty(ShadowPlanB2HueShiftFromBase, "Hue Shift");
+                                materialEditor.ShaderProperty(ShadowPlanB2SaturationFromBase, "Saturation");
+                                materialEditor.ShaderProperty(ShadowPlanB2ValueFromBase, "Value");
                             }
-                            EditorGUI.indentLevel --;
                         }
+
+                        EditorGUI.indentLevel --;
                         EditorGUI.indentLevel --;
                     }
                     EditorGUI.indentLevel --;

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -23,8 +23,8 @@ namespace ArktoonShaders
         MaterialProperty BumpScale;
         MaterialProperty EmissionMap;
         MaterialProperty EmissionColor;
-        MaterialProperty ShadowborderMin;
-        MaterialProperty ShadowborderMax;
+        MaterialProperty Shadowborder;
+        MaterialProperty ShadowborderBlur;
         MaterialProperty ShadowStrength;
         MaterialProperty ShadowUseStep;
         MaterialProperty ShadowSteps;
@@ -32,7 +32,7 @@ namespace ArktoonShaders
         MaterialProperty ShadowStrengthMask;
         MaterialProperty CutoutCutoutAdjust;
         MaterialProperty ShadowPlanBUsePlanB;
-        MaterialProperty ShadowPlanBUseShadowMix;
+        MaterialProperty ShadowPlanBDefaultShadowMix;
         MaterialProperty ShadowPlanBUseCustomShadowTexture;
         MaterialProperty ShadowPlanBHueShiftFromBase;
         MaterialProperty ShadowPlanBSaturationFromBase;
@@ -101,15 +101,15 @@ namespace ArktoonShaders
             EmissionMap = FindProperty("_EmissionMap", props);
             EmissionColor = FindProperty("_EmissionColor", props);
             if(isCutout) CutoutCutoutAdjust = FindProperty("_CutoutCutoutAdjust", props);
-            ShadowborderMin = FindProperty("_ShadowborderMin", props);
-            ShadowborderMax = FindProperty("_ShadowborderMax", props);
+            Shadowborder = FindProperty("_Shadowborder", props);
+            ShadowborderBlur = FindProperty("_ShadowborderBlur", props);
             ShadowStrength = FindProperty("_ShadowStrength", props);
             ShadowUseStep = FindProperty("_ShadowUseStep", props);
             ShadowSteps = FindProperty("_ShadowSteps", props);
             PointShadowStrength = FindProperty("_PointShadowStrength", props);
             ShadowStrengthMask = FindProperty("_ShadowStrengthMask", props);
             ShadowPlanBUsePlanB = FindProperty("_ShadowPlanBUsePlanB", props);
-            ShadowPlanBUseShadowMix = FindProperty("_ShadowPlanBUseShadowMix", props);
+            ShadowPlanBDefaultShadowMix = FindProperty("_ShadowPlanBDefaultShadowMix", props);
             ShadowPlanBUseCustomShadowTexture = FindProperty("_ShadowPlanBUseCustomShadowTexture", props);
             ShadowPlanBHueShiftFromBase = FindProperty("_ShadowPlanBHueShiftFromBase", props);
             ShadowPlanBSaturationFromBase = FindProperty("_ShadowPlanBSaturationFromBase", props);
@@ -186,9 +186,14 @@ namespace ArktoonShaders
                 EditorGUILayout.LabelField("Shadow", EditorStyles.boldLabel);
                 {
                     EditorGUI.indentLevel ++;
-                    materialEditor.ShaderProperty(ShadowborderMin, "Shadow border End");
-                    materialEditor.ShaderProperty(ShadowborderMax, "Shadow border Begin");
-                    materialEditor.ShaderProperty(ShadowStrength, "Shadow Strength");
+                    materialEditor.ShaderProperty(Shadowborder, "Shadow border");
+                    materialEditor.ShaderProperty(ShadowborderBlur, "Shadow border blur");
+                    if(ShadowPlanBUsePlanB.floatValue > 0)
+                    {
+                        EditorGUILayout.LabelField("Shadow Strength (disabled)");
+                    } else {
+                        materialEditor.ShaderProperty(ShadowStrength, "Shadow Strength");
+                    }
                     materialEditor.ShaderProperty(ShadowStrengthMask, "Shadow Strength Mask");
                     materialEditor.ShaderProperty(ShadowUseStep, "Use Shadow Steps");
                     var useStep = ShadowUseStep.floatValue;
@@ -202,7 +207,7 @@ namespace ArktoonShaders
                     if(usePlanB > 0)
                     {
                         EditorGUI.indentLevel ++;
-                        materialEditor.ShaderProperty(ShadowPlanBUseShadowMix, "Mix Default Shadow");
+                        materialEditor.ShaderProperty(ShadowPlanBDefaultShadowMix, "Mix Default Shadow");
                         materialEditor.ShaderProperty(ShadowPlanBUseCustomShadowTexture, "Use Shade Texture");
                         var useShadeTexture = ShadowPlanBUseCustomShadowTexture.floatValue;
                         if(useShadeTexture > 0)

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -39,6 +39,11 @@ namespace ArktoonShaders
         MaterialProperty ShadowPlanBValueFromBase;
         MaterialProperty ShadowPlanBCustomShadowTexture;
         MaterialProperty ShadowPlanBCustomShadowTextureRGB;
+        MaterialProperty CustomShadow2nd;
+        MaterialProperty ShadowPlanB2borderMin;
+        MaterialProperty ShadowPlanB2borderMax;
+        MaterialProperty ShadowPlanB2CustomShadowTexture;
+        MaterialProperty ShadowPlanB2CustomShadowTextureRGB;
         MaterialProperty UseGloss;
         MaterialProperty GlossBlend;
         MaterialProperty GlossBlendMask;
@@ -116,6 +121,13 @@ namespace ArktoonShaders
             ShadowPlanBValueFromBase = FindProperty("_ShadowPlanBValueFromBase", props);
             ShadowPlanBCustomShadowTexture = FindProperty("_ShadowPlanBCustomShadowTexture", props);
             ShadowPlanBCustomShadowTextureRGB = FindProperty("_ShadowPlanBCustomShadowTextureRGB", props);
+
+            CustomShadow2nd = FindProperty("_CustomShadow2nd", props);
+            ShadowPlanB2borderMin = FindProperty("_ShadowPlanB2borderMin", props);
+            ShadowPlanB2borderMax = FindProperty("_ShadowPlanB2borderMax", props);
+            ShadowPlanB2CustomShadowTexture = FindProperty("_ShadowPlanB2CustomShadowTexture", props);
+            ShadowPlanB2CustomShadowTextureRGB = FindProperty("_ShadowPlanB2CustomShadowTextureRGB", props);
+
             UseGloss = FindProperty("_UseGloss", props);
             GlossBlend = FindProperty("_GlossBlend", props);
             GlossBlendMask = FindProperty("_GlossBlendMask", props);
@@ -220,6 +232,17 @@ namespace ArktoonShaders
                             materialEditor.ShaderProperty(ShadowPlanBHueShiftFromBase, "Hue Shift");
                             materialEditor.ShaderProperty(ShadowPlanBSaturationFromBase, "Saturation");
                             materialEditor.ShaderProperty(ShadowPlanBValueFromBase, "Value");
+                        }
+                        materialEditor.ShaderProperty(CustomShadow2nd, "Use Shade2 Texture");
+                        var customshadow2nd = CustomShadow2nd.floatValue;
+                        if(customshadow2nd > 0)
+                        {
+                            EditorGUI.indentLevel ++;
+                            materialEditor.ShaderProperty(ShadowPlanB2borderMax, "Border End");
+                            materialEditor.ShaderProperty(ShadowPlanB2borderMin, "Border Begin");
+                            materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTexture,  "Shade Texture");
+                            materialEditor.ShaderProperty(ShadowPlanB2CustomShadowTextureRGB,  "Shade Texture RGB");
+                            EditorGUI.indentLevel --;
                         }
                         EditorGUI.indentLevel --;
                     }

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -90,7 +90,11 @@ namespace ArktoonShaders
         MaterialProperty ShadowCapColor;
         MaterialProperty Cull;
         MaterialProperty ZWrite;
+        MaterialProperty OtherShadowBorderSharpness;
+        MaterialProperty OtherShadowAdjust;
         #endregion
+
+        bool _isOpenAdvance;
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
@@ -178,6 +182,8 @@ namespace ArktoonShaders
             ShadowCapTexture = FindProperty("_ShadowCapTexture", props);
             ShadowCapColor = FindProperty("_ShadowCapColor", props);
             Cull = FindProperty("_Cull", props);
+            OtherShadowBorderSharpness = FindProperty("_OtherShadowBorderSharpness", props);
+            OtherShadowAdjust = FindProperty("_OtherShadowAdjust", props);
             if(isFade) ZWrite = FindProperty("_ZWrite", props);
 
             EditorGUIUtility.labelWidth = 0f;
@@ -190,6 +196,8 @@ namespace ArktoonShaders
                     materialEditor.TexturePropertySingleLine(new GUIContent("Main Texture", "Base Color Texture (RGB)"), BaseTexture, BaseColor);
                     materialEditor.TexturePropertySingleLine(new GUIContent("Normal Map", "Normal Map (RGB)"), Normalmap, BumpScale);
                     materialEditor.TexturePropertySingleLine(new GUIContent("Emission", "Emission (RGB)"), EmissionMap, EmissionColor);
+                    materialEditor.ShaderProperty(Cull, "Cull");
+                    if(isFade) materialEditor.ShaderProperty(ZWrite, "ZWrite");
                     EditorGUI.indentLevel --;
                 }
 
@@ -384,14 +392,25 @@ namespace ArktoonShaders
 
                 EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
                 EditorGUILayout.LabelField("Advanced", EditorStyles.boldLabel);
+                EditorGUILayout.HelpBox("These are some shade tweaking. no need to change usually." + Environment.NewLine + "ほとんどのケースで触る必要のないやつら。",MessageType.Info);
+                if (GUILayout.Button("Revert advanced params.")){
+                    PointShadowStrength.floatValue = 1.0f;
+                    OtherShadowAdjust.floatValue = -0.1f;
+                    OtherShadowBorderSharpness.floatValue = 3;
+                }
                 {
                     EditorGUI.indentLevel ++;
-                    materialEditor.ShaderProperty(Cull, "Cull");
-                    if(isFade) materialEditor.ShaderProperty(ZWrite, "ZWrite");
                     EditorGUILayout.LabelField("PointLight Shadows", EditorStyles.boldLabel);
                     {
                         EditorGUI.indentLevel ++;
-                        materialEditor.ShaderProperty(PointShadowStrength, "Strength");
+                        materialEditor.ShaderProperty(PointShadowStrength, "Strength (def:1.0)");
+                        EditorGUI.indentLevel --;
+                    }
+                    EditorGUILayout.LabelField("Shade from other meshes", EditorStyles.boldLabel);
+                    {
+                        EditorGUI.indentLevel ++;
+                        materialEditor.ShaderProperty(OtherShadowAdjust, "Adjust (def:-0.1)");
+                        materialEditor.ShaderProperty(OtherShadowBorderSharpness, "Sharpness(def:3)");
                         EditorGUI.indentLevel --;
                     }
                     EditorGUI.indentLevel --;

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -29,7 +29,7 @@ Shader "arktoon/AlphaCutout" {
         [Toggle(USE_CUSTOM_SHADOW_TEXTURE)] _ShadowPlanBUseCustomShadowTexture ("[Plan B] Use Custom Shadow Texture", Float ) = 0
         _ShadowPlanBHueShiftFromBase ("[Plan B] Hue Shift From Base", Range(-1, 1)) = 0
         _ShadowPlanBSaturationFromBase ("[Plan B] Saturation From Base", Range(0, 2)) = 1
-        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 0
+        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 1
         _ShadowPlanBCustomShadowTexture ("[Plan B] Custom Shadow Texture", 2D) = "black" {}
         _ShadowPlanBCustomShadowTextureRGB ("[Plan B] Custom Shadow Texture RGB", Color) = (1,1,1,1)
         // Gloss

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -153,58 +153,8 @@ Shader "arktoon/AlphaCutout" {
             uniform float4 _ShadowCapColor;
             uniform float _ShadowCapNormalMix;
 
-            struct VertexInput {
-                float4 vertex : POSITION;
-                float3 normal : NORMAL;
-                float4 tangent : TANGENT;
-                float2 texcoord0 : TEXCOORD0;
-            };
-            struct VertexOutput {
-                float4 pos : SV_POSITION;
-                float2 uv0 : TEXCOORD0;
-                float4 posWorld : TEXCOORD1;
-                float3 normalDir : TEXCOORD2;
-                float3 tangentDir : TEXCOORD3;
-                float3 bitangentDir : TEXCOORD4;
-                float3 ambient : TEXCOORD6;
-                float3 ambientAtten : TEXCOORD7;
-                LIGHTING_COORDS(5,6)
-                UNITY_FOG_COORDS(7)
-            };
-            VertexOutput vert (VertexInput v) {
-                VertexOutput o = (VertexOutput)0;
-                o.uv0 = v.texcoord0;
-                o.normalDir = UnityObjectToWorldNormal(v.normal);
-                o.tangentDir = normalize( mul( unity_ObjectToWorld, float4( v.tangent.xyz, 0.0 ) ).xyz );
-                o.bitangentDir = normalize(cross(o.normalDir, o.tangentDir) * v.tangent.w);
-                o.posWorld = mul(unity_ObjectToWorld, v.vertex);
-                o.pos = UnityObjectToClipPos( v.vertex );
-                UNITY_TRANSFER_FOG(o,o.pos);
-                TRANSFER_VERTEX_TO_FRAGMENT(o)
+            // vert は arklude.cginc に移動
 
-                // 頂点ライティングが必要ば場合に取得
-                #if UNITY_SHOULD_SAMPLE_SH
-                    #if defined(VERTEXLIGHT_ON)
-                        o.ambient = Shade4PointLights(
-                            unity_4LightPosX0, unity_4LightPosY0, unity_4LightPosZ0,
-                            unity_LightColor[0].rgb, unity_LightColor[1].rgb,
-                            unity_LightColor[2].rgb, unity_LightColor[3].rgb,
-                            unity_4LightAtten0, o.posWorld, o.normalDir
-                        );
-                        o.ambientAtten = Shade4PointLightsIndirect(
-                            unity_4LightPosX0, unity_4LightPosY0, unity_4LightPosZ0,
-                            unity_LightColor[0].rgb, unity_LightColor[1].rgb,
-                            unity_LightColor[2].rgb, unity_LightColor[3].rgb,
-                            unity_4LightAtten0, o.posWorld, o.normalDir
-                        );
-                    #else
-                        o.ambient = o.ambientAtten = 0;
-                    #endif
-                #else
-                    o.ambient = o.ambientAtten = 0;
-                #endif
-                return o;
-            }
             float4 frag(VertexOutput i) : COLOR {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
@@ -244,9 +194,8 @@ Shader "arktoon/AlphaCutout" {
                 float topIndirectLighting = dot(ShadeSH9Plus,grayscale_vector);
                 float lightDifference = ((topIndirectLighting+grayscalelightcolor)-bottomIndirectLighting);
                 float remappedLight = ((grayscaleDirectLighting-bottomIndirectLighting)/lightDifference);
-                float node_4614 = 0.0;
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
-                float directContribution = (1.0 - ((1.0 - saturate((node_4614 + ( (saturate(remappedLight) - _ShadowborderMin) * (1.0 - node_4614) ) / (_ShadowborderMax - _ShadowborderMin)))) * _ShadowStrengthMask_var * _ShadowStrength));
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))) * _ShadowStrengthMask_var * _ShadowStrength);
 
                 // 頂点ライティングを処理
 				float3 lightContribution = lerp(i.ambient, i.ambientAtten, 1-_PointShadowStrength);
@@ -397,7 +346,6 @@ Shader "arktoon/AlphaCutout" {
                 o.tangentDir = normalize( mul( unity_ObjectToWorld, float4( v.tangent.xyz, 0.0 ) ).xyz );
                 o.bitangentDir = normalize(cross(o.normalDir, o.tangentDir) * v.tangent.w);
                 o.posWorld = mul(unity_ObjectToWorld, v.vertex);
-                float3 lightColor = _LightColor0.rgb;
                 o.pos = UnityObjectToClipPos( v.vertex );
                 UNITY_TRANSFER_FOG(o,o.pos);
                 TRANSFER_VERTEX_TO_FRAGMENT(o)
@@ -441,7 +389,7 @@ Shader "arktoon/AlphaCutout" {
                 float3 directContribution = (1.0 - (1.0 - saturate(saturate(lightContribution))));
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
                 float3 finalLight = saturate(directContribution + ((1 - (_PointShadowStrength * _ShadowStrengthMask_var)) * attenuation));
-                float3 coloredLight = lerp(0, _LightColor0.rgb, finalLight);
+                float3 coloredLight = lightColor*finalLight;
 
                 #ifdef USE_MATCAP
                     float3 normalDirectionMatcap = normalize(mul( float3(normalLocal.r*_MatcapNormalMix,normalLocal.g*_MatcapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
@@ -449,7 +397,7 @@ Shader "arktoon/AlphaCutout" {
                     float4 _MatcapTexture_var = tex2D(_MatcapTexture,TRANSFORM_TEX(transformMatcap, _MatcapTexture));
                     float4 _MatcapBlendMask_var = tex2D(_MatcapBlendMask,TRANSFORM_TEX(i.uv0, _MatcapBlendMask));
                     float3 matcap = ((_MatcapColor.rgb*_MatcapTexture_var.rgb)*_MatcapBlendMask_var.rgb*_MatcapBlend);
-                    matcap = min(matcap, matcap * lerp(float3(0,0,0), coloredLight, _MatcapShadeMix));
+                    matcap = min(matcap, matcap * (coloredLight * _MatcapShadeMix));
                 #else
                     float3 matcap = float3(0,0,0);
                 #endif
@@ -458,7 +406,7 @@ Shader "arktoon/AlphaCutout" {
                     float _RimBlendMask_var = tex2D(_RimBlendMask, TRANSFORM_TEX(i.uv0, _RimBlendMask));
                     float4 _RimTexture_var = tex2D(_RimTexture,TRANSFORM_TEX(i.uv0, _RimTexture));
                     float3 RimLight = (lerp( _RimTexture_var.rgb, Diffuse, _RimUseBaseTexture )*pow(1.0-max(0,dot(normalDirection, viewDirection)),_RimFresnelPower)*_RimBlend*_RimColor.rgb*_RimBlendMask_var);
-                    RimLight = min(RimLight, RimLight * lerp(float3(0,0,0), coloredLight, _RimShadeMix));
+                    RimLight = min(RimLight, RimLight * (coloredLight * _RimShadeMix));
                 #else
                     float3 RimLight = float3(0,0,0);
                 #endif

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -18,24 +18,35 @@ Shader "arktoon/AlphaCutout" {
         // Cutout
         _CutoutCutoutAdjust ("Cutout Border Adjust", Range(0, 1)) = 0.5
         // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
-        _ShadowborderMin ("[Shadow] border Min", Range(0, 1)) = 0.499
-        _ShadowborderMax ("[Shadow] border Max", Range(0, 1)) = 0.55
+        _Shadowborder ("[Shadow] border ", Range(0, 1)) = 0.6
+        _ShadowborderBlur ("[Shadow] border Blur", Range(0, 1)) = 0.05
         _ShadowStrength ("[Shadow] Strength", Range(0, 1)) = 0.5
         _ShadowStrengthMask ("[Shadow] Strength Mask", 2D) = "white" {}
         // Shadow steps
         [Toggle(USE_SHADOW_STEPS)]_ShadowUseStep ("[Shadow] use step", Float ) = 0
         _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
         // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
-        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.25
+        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 1
         // Plan B
         [Toggle(USE_SHADE_TEXTURE)]_ShadowPlanBUsePlanB ("[Plan B] Use Plan B", Float ) = 0
-        [Toggle(USE_SHADOW_MIX)]_ShadowPlanBUseShadowMix ("[Plan B] Use Shadow Mix", Float ) = 0
+        _ShadowPlanBDefaultShadowMix ("[Plan B] Shadow mix", Range(0, 1)) = 1
         [Toggle(USE_CUSTOM_SHADOW_TEXTURE)] _ShadowPlanBUseCustomShadowTexture ("[Plan B] Use Custom Shadow Texture", Float ) = 0
         _ShadowPlanBHueShiftFromBase ("[Plan B] Hue Shift From Base", Range(-1, 1)) = 0
         _ShadowPlanBSaturationFromBase ("[Plan B] Saturation From Base", Range(0, 2)) = 1
         _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 1
         _ShadowPlanBCustomShadowTexture ("[Plan B] Custom Shadow Texture", 2D) = "black" {}
         _ShadowPlanBCustomShadowTextureRGB ("[Plan B] Custom Shadow Texture RGB", Color) = (1,1,1,1)
+        // ShadowPlanB-2
+        [Toggle(USE_CUSTOM_SHADOW_2ND)]_CustomShadow2nd ("[Plan B-2] CustomShadow2nd", Float ) = 0
+        _ShadowPlanB2border ("[Plan B-2] border ", Range(0, 1)) = 0.55
+        _ShadowPlanB2borderBlur ("[Plan B-2] border Blur", Range(0, 1)) = 0.55
+        [Toggle(USE_CUSTOM_SHADOW_TEXTURE_2ND)] _ShadowPlanB2UseCustomShadowTexture ("[Plan B-2] Use Custom Shadow Texture", Float ) = 0
+        _ShadowPlanB2HueShiftFromBase ("[Plan B-2] Hue Shift From Base", Range(-1, 1)) = 0
+        _ShadowPlanB2SaturationFromBase ("[Plan B-2] Saturation From Base", Range(0, 2)) = 1
+        _ShadowPlanB2ValueFromBase ("[Plan B-2] Value From Base", Range(0, 2)) = 1
+        _ShadowPlanB2CustomShadowTexture ("[Plan B-2] Custom Shadow Texture", 2D) = "black" {}
+        _ShadowPlanB2CustomShadowTextureRGB ("[Plan B-2] Custom Shadow Texture RGB", Color) = (1,1,1,1)
+
         // Gloss
         [Toggle(USE_GLOSS)]_UseGloss ("[Gloss] Enabled", Float) = 0
         _GlossBlend ("[Gloss] Blend", Range(0, 1)) = 1
@@ -82,6 +93,9 @@ Shader "arktoon/AlphaCutout" {
         _ShadowCapNormalMix ("[ShadowCap] Normal map mix", Range(0, 2)) = 1
         _ShadowCapTexture ("[ShadowCap] Texture", 2D) = "white" {}
         _ShadowCapColor ("[ShadowCap] Color", Color) = (1,1,1,1)
+        // advanced tweaking
+        _OtherShadowAdjust ("[Advanced] Other Mesh Shadow Adjust", Range(-0.2, 0.2)) = -0.1
+        _OtherShadowBorderSharpness ("[Advanced] Other Mesh Shadow Border Sharpness", Range(1, 5)) = 3
     }
     SubShader {
         Tags {
@@ -96,7 +110,6 @@ Shader "arktoon/AlphaCutout" {
 
             CGPROGRAM
             #pragma shader_feature USE_SHADE_TEXTURE
-            #pragma shader_feature USE_SHADOW_MIX
             #pragma shader_feature USE_GLOSS
             #pragma shader_feature USE_MATCAP
             #pragma shader_feature USE_REFLECTION
@@ -104,6 +117,9 @@ Shader "arktoon/AlphaCutout" {
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
             #pragma shader_feature USE_SHADOW_STEPS
+            #pragma shader_feature USE_CUSTOM_SHADOW_2ND
+            #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE_2ND
+
             #pragma multi_compile _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
             #pragma multi_compile _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY
 
@@ -122,11 +138,21 @@ Shader "arktoon/AlphaCutout" {
             uniform float _GlossPower;
             uniform float4 _GlossColor;
             uniform float _CutoutCutoutAdjust;
+            uniform float _ShadowPlanBDefaultShadowMix;
             uniform float _ShadowPlanBHueShiftFromBase;
             uniform float _ShadowPlanBSaturationFromBase;
             uniform float _ShadowPlanBValueFromBase;
-            uniform float _ShadowborderMin;
-            uniform float _ShadowborderMax;
+
+            uniform float _ShadowPlanB2border;
+            uniform float _ShadowPlanB2borderBlur;
+            uniform float _ShadowPlanB2HueShiftFromBase;
+            uniform float _ShadowPlanB2SaturationFromBase;
+            uniform float _ShadowPlanB2ValueFromBase;
+            uniform sampler2D _ShadowPlanB2CustomShadowTexture; uniform float4 _ShadowPlanB2CustomShadowTexture_ST;
+            uniform float4 _ShadowPlanB2CustomShadowTextureRGB;
+
+            uniform float _Shadowborder;
+            uniform float _ShadowborderBlur;
             uniform float _ShadowStrength;
             uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
@@ -163,6 +189,8 @@ Shader "arktoon/AlphaCutout" {
             uniform float _ShadowCapBlend;
             uniform float4 _ShadowCapColor;
             uniform float _ShadowCapNormalMix;
+            uniform float _OtherShadowAdjust;
+            uniform float _OtherShadowBorderSharpness;
 
             // vert は arklude.cginc に移動
 
@@ -206,17 +234,25 @@ Shader "arktoon/AlphaCutout" {
                 float lightDifference = ((topIndirectLighting+grayscalelightcolor)-bottomIndirectLighting);
                 float remappedLight = ((grayscaleDirectLighting-bottomIndirectLighting)/lightDifference);
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))));
 
-                float selfShade = max(0,min(1,(dot(lightDirection,normalDirection)+1)));
-                float otherShadow = saturate((attenuation))+saturate(1-selfShade);
+                float ShadowborderMin = max(0, _Shadowborder - _ShadowborderBlur/2);
+                float ShadowborderMax = min(1, _Shadowborder + _ShadowborderBlur/2);
+
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
+
+                float selfShade = saturate(dot(lightDirection,normalDirection)+1+_OtherShadowAdjust);
+                float otherShadow = saturate(saturate((attenuation-0.5)*2)+(1-selfShade)*_OtherShadowBorderSharpness);
                 directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())))));
 
                 #ifdef USE_SHADOW_STEPS
                     directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
                 #endif
 
-                directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * _ShadowStrength;
+                #ifdef USE_SHADE_TEXTURE
+                    directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * 1;
+                #else
+                	directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * _ShadowStrength;
+                #endif
 
                 // 頂点ライティングを処理
 				float3 lightContribution = lerp(i.ambient, i.ambientAtten, 1-_PointShadowStrength);
@@ -227,11 +263,7 @@ Shader "arktoon/AlphaCutout" {
                 float3 finalLight = lerp(indirectLighting,directLighting,directContribution)+coloredLight;
 
                 #ifdef USE_SHADE_TEXTURE
-                    #ifdef USE_SHADOW_MIX
-                        float3 shadeMixValue = finalLight;
-                    #else
-                        float3 shadeMixValue = directLighting;
-                    #endif
+                    float3 shadeMixValue = lerp(directLighting, finalLight, _ShadowPlanBDefaultShadowMix);
                     #ifdef USE_CUSTOM_SHADOW_TEXTURE
                         float4 _ShadowPlanBCustomShadowTexture_var = tex2D(_ShadowPlanBCustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanBCustomShadowTexture));
                         float3 shadowCustomTexture = _ShadowPlanBCustomShadowTexture_var.rgb * _ShadowPlanBCustomShadowTextureRGB.rgb;
@@ -240,7 +272,24 @@ Shader "arktoon/AlphaCutout" {
                         float3 Diff_HSV = CalculateHSV(Diffuse, _ShadowPlanBHueShiftFromBase, _ShadowPlanBSaturationFromBase, _ShadowPlanBValueFromBase);
                         float3 ShadeMap = Diff_HSV*shadeMixValue;
                     #endif
-                    float3 ToonedMap = (lerp(ShadeMap,Diffuse*finalLight,finalLight)/1.0);
+
+                    #ifdef USE_CUSTOM_SHADOW_2ND
+                        float ShadowborderMin2 = max(0, (_ShadowPlanB2border * _Shadowborder) - _ShadowPlanB2borderBlur/2);
+                        float ShadowborderMax2 = min(1, (_ShadowPlanB2border * _Shadowborder) + _ShadowPlanB2borderBlur/2);
+                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));
+                        #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
+                            float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));
+                            float3 shadowCustomTexture2 = _ShadowPlanB2CustomShadowTexture_var.rgb * _ShadowPlanB2CustomShadowTextureRGB.rgb;
+                            float3 ShadeMap2 = shadowCustomTexture2*shadeMixValue;
+                        #else
+                            float3 Diff_HSV2 = CalculateHSV(Diffuse, _ShadowPlanB2HueShiftFromBase, _ShadowPlanB2SaturationFromBase, _ShadowPlanB2ValueFromBase);
+                            float3 ShadeMap2 = Diff_HSV2*shadeMixValue;
+                        #endif
+                        ShadeMap = lerp(ShadeMap2,ShadeMap,directContribution2);
+                    #endif
+
+                    finalLight = lerp(ShadeMap,directLighting,directContribution)+coloredLight;
+                    float3 ToonedMap = lerp(ShadeMap,Diffuse*finalLight,finalLight);
                 #else
                     float3 ToonedMap = Diffuse*finalLight;
                 #endif

--- a/Assets/arktoon Shaders/Shaders/Cutout.shader
+++ b/Assets/arktoon Shaders/Shaders/Cutout.shader
@@ -238,11 +238,13 @@ Shader "arktoon/AlphaCutout" {
                 float ShadowborderMin = max(0, _Shadowborder - _ShadowborderBlur/2);
                 float ShadowborderMax = min(1, _Shadowborder + _ShadowborderBlur/2);
 
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
+                float grayscaleDirectLighting2 = (((dot(lightDirection,normalDirection)*0.5+0.5)*grayscalelightcolor) + dot(ShadeSH9Normal( normalDirection ),grayscale_vector));
+                float remappedLight2 = ((grayscaleDirectLighting2-bottomIndirectLighting)/lightDifference);
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight2) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
 
                 float selfShade = saturate(dot(lightDirection,normalDirection)+1+_OtherShadowAdjust);
                 float otherShadow = saturate(saturate((attenuation-0.5)*2)+(1-selfShade)*_OtherShadowBorderSharpness);
-                directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())))));
+                directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())*1.5))));
 
                 #ifdef USE_SHADOW_STEPS
                     directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
@@ -276,7 +278,7 @@ Shader "arktoon/AlphaCutout" {
                     #ifdef USE_CUSTOM_SHADOW_2ND
                         float ShadowborderMin2 = max(0, (_ShadowPlanB2border * _Shadowborder) - _ShadowPlanB2borderBlur/2);
                         float ShadowborderMax2 = min(1, (_ShadowPlanB2border * _Shadowborder) + _ShadowPlanB2borderBlur/2);
-                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));
+                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate((remappedLight+remappedLight2)/2) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));  // /2の部分をパラメーターにしたい
                         #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
                             float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));
                             float3 shadowCustomTexture2 = _ShadowPlanB2CustomShadowTexture_var.rgb * _ShadowPlanB2CustomShadowTextureRGB.rgb;

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -28,7 +28,7 @@ Shader "arktoon/Fade" {
         [Toggle(USE_CUSTOM_SHADOW_TEXTURE)] _ShadowPlanBUseCustomShadowTexture ("[Plan B] Use Custom Shadow Texture", Float ) = 0
         _ShadowPlanBHueShiftFromBase ("[Plan B] Hue Shift From Base", Range(-1, 1)) = 0
         _ShadowPlanBSaturationFromBase ("[Plan B] Saturation From Base", Range(0, 2)) = 1
-        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 0
+        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 1
         _ShadowPlanBCustomShadowTexture ("[Plan B] Custom Shadow Texture", 2D) = "black" {}
         _ShadowPlanBCustomShadowTextureRGB ("[Plan B] Custom Shadow Texture RGB", Color) = (1,1,1,1)
         // Gloss

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -17,8 +17,8 @@ Shader "arktoon/Fade" {
         _EmissionMap ("[Common] Emission map", 2D) = "white" {}
         _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
         // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
-        _ShadowborderMin ("[Shadow] border Min", Range(0, 1)) = 0.499
-        _ShadowborderMax ("[Shadow] border Max", Range(0, 1)) = 0.55
+        _Shadowborder ("[Shadow] border ", Range(0, 1)) = 0.6
+        _ShadowborderBlur ("[Shadow] border Blur", Range(0, 1)) = 0.05
         _ShadowStrength ("[Shadow] Strength", Range(0, 1)) = 0.5
         _ShadowStrengthMask ("[Shadow] Strength Mask", 2D) = "white" {}
         // Shadow steps
@@ -28,13 +28,24 @@ Shader "arktoon/Fade" {
         _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.25
         // Plan B
         [Toggle(USE_SHADE_TEXTURE)]_ShadowPlanBUsePlanB ("[Plan B] Use Plan B", Float ) = 0
-        [Toggle(USE_SHADOW_MIX)]_ShadowPlanBUseShadowMix ("[Plan B] Use Shadow Mix", Float ) = 0
+        _ShadowPlanBDefaultShadowMix ("[Plan B] Shadow mix", Range(0, 1)) = 1
         [Toggle(USE_CUSTOM_SHADOW_TEXTURE)] _ShadowPlanBUseCustomShadowTexture ("[Plan B] Use Custom Shadow Texture", Float ) = 0
         _ShadowPlanBHueShiftFromBase ("[Plan B] Hue Shift From Base", Range(-1, 1)) = 0
         _ShadowPlanBSaturationFromBase ("[Plan B] Saturation From Base", Range(0, 2)) = 1
         _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 1
         _ShadowPlanBCustomShadowTexture ("[Plan B] Custom Shadow Texture", 2D) = "black" {}
         _ShadowPlanBCustomShadowTextureRGB ("[Plan B] Custom Shadow Texture RGB", Color) = (1,1,1,1)
+        // ShadowPlanB-2
+        [Toggle(USE_CUSTOM_SHADOW_2ND)]_CustomShadow2nd ("[Plan B-2] CustomShadow2nd", Float ) = 0
+        _ShadowPlanB2border ("[Plan B-2] border ", Range(0, 1)) = 0.55
+        _ShadowPlanB2borderBlur ("[Plan B-2] border Blur", Range(0, 1)) = 0.55
+        [Toggle(USE_CUSTOM_SHADOW_TEXTURE_2ND)] _ShadowPlanB2UseCustomShadowTexture ("[Plan B-2] Use Custom Shadow Texture", Float ) = 0
+        _ShadowPlanB2HueShiftFromBase ("[Plan B-2] Hue Shift From Base", Range(-1, 1)) = 0
+        _ShadowPlanB2SaturationFromBase ("[Plan B-2] Saturation From Base", Range(0, 2)) = 1
+        _ShadowPlanB2ValueFromBase ("[Plan B-2] Value From Base", Range(0, 2)) = 1
+        _ShadowPlanB2CustomShadowTexture ("[Plan B-2] Custom Shadow Texture", 2D) = "black" {}
+        _ShadowPlanB2CustomShadowTextureRGB ("[Plan B-2] Custom Shadow Texture RGB", Color) = (1,1,1,1)
+
         // Gloss
         [Toggle(USE_GLOSS)]_UseGloss ("[Gloss] Enabled", Float) = 0
         _GlossBlend ("[Gloss] Blend", Range(0, 1)) = 1
@@ -75,6 +86,9 @@ Shader "arktoon/Fade" {
         _ShadowCapNormalMix ("[ShadowCap] Normal map mix", Range(0, 2)) = 1
         _ShadowCapTexture ("[ShadowCap] Texture", 2D) = "white" {}
         _ShadowCapColor ("[ShadowCap] Color", Color) = (1,1,1,1)
+        // advanced tweaking
+        _OtherShadowAdjust ("[Advanced] Other Mesh Shadow Adjust", Range(-0.2, 0.2)) = -0.1
+        _OtherShadowBorderSharpness ("[Advanced] Other Mesh Shadow Border Sharpness", Range(1, 5)) = 3
     }
     SubShader {
         Tags {
@@ -92,7 +106,6 @@ Shader "arktoon/Fade" {
 
             CGPROGRAM
             #pragma shader_feature USE_SHADE_TEXTURE
-            #pragma shader_feature USE_SHADOW_MIX
             #pragma shader_feature USE_GLOSS
             #pragma shader_feature USE_MATCAP
             #pragma shader_feature USE_REFLECTION
@@ -100,6 +113,9 @@ Shader "arktoon/Fade" {
             #pragma shader_feature USE_SHADOWCAP
             #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
             #pragma shader_feature USE_SHADOW_STEPS
+            #pragma shader_feature USE_CUSTOM_SHADOW_2ND
+            #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE_2ND
+
             #pragma multi_compile _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
             #pragma multi_compile _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY
 
@@ -117,11 +133,21 @@ Shader "arktoon/Fade" {
             uniform float4 _Color;
             uniform float _GlossPower;
             uniform float4 _GlossColor;
+            uniform float _ShadowPlanBDefaultShadowMix;
             uniform float _ShadowPlanBHueShiftFromBase;
             uniform float _ShadowPlanBSaturationFromBase;
             uniform float _ShadowPlanBValueFromBase;
-            uniform float _ShadowborderMin;
-            uniform float _ShadowborderMax;
+
+            uniform float _ShadowPlanB2border;
+            uniform float _ShadowPlanB2borderBlur;
+            uniform float _ShadowPlanB2HueShiftFromBase;
+            uniform float _ShadowPlanB2SaturationFromBase;
+            uniform float _ShadowPlanB2ValueFromBase;
+            uniform sampler2D _ShadowPlanB2CustomShadowTexture; uniform float4 _ShadowPlanB2CustomShadowTexture_ST;
+            uniform float4 _ShadowPlanB2CustomShadowTextureRGB;
+
+            uniform float _Shadowborder;
+            uniform float _ShadowborderBlur;
             uniform float _ShadowStrength;
             uniform int _ShadowSteps;
             uniform float _PointShadowStrength;
@@ -158,6 +184,8 @@ Shader "arktoon/Fade" {
             uniform float _ShadowCapBlend;
             uniform float4 _ShadowCapColor;
             uniform float _ShadowCapNormalMix;
+            uniform float _OtherShadowAdjust;
+            uniform float _OtherShadowBorderSharpness;
 
             // vert は arklude.cginc に移動
 
@@ -200,17 +228,25 @@ Shader "arktoon/Fade" {
                 float lightDifference = ((topIndirectLighting+grayscalelightcolor)-bottomIndirectLighting);
                 float remappedLight = ((grayscaleDirectLighting-bottomIndirectLighting)/lightDifference);
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))));
 
-                float selfShade = max(0,min(1,(dot(lightDirection,normalDirection)+1)));
-                float otherShadow = saturate((attenuation))+saturate(1-selfShade);
+                float ShadowborderMin = max(0, _Shadowborder - _ShadowborderBlur/2);
+                float ShadowborderMax = min(1, _Shadowborder + _ShadowborderBlur/2);
+
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
+
+                float selfShade = saturate(dot(lightDirection,normalDirection)+1+_OtherShadowAdjust);
+                float otherShadow = saturate(saturate((attenuation-0.5)*2)+(1-selfShade)*_OtherShadowBorderSharpness);
                 directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())))));
 
                 #ifdef USE_SHADOW_STEPS
                     directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
                 #endif
 
-                directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * _ShadowStrength;
+                #ifdef USE_SHADE_TEXTURE
+                    directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * 1;
+                #else
+                	directContribution = 1.0 - (1.0 - directContribution) * _ShadowStrengthMask_var * _ShadowStrength;
+                #endif
 
                 // 頂点ライティングを処理
 				float3 lightContribution = lerp(i.ambient, i.ambientAtten, 1-_PointShadowStrength);
@@ -221,11 +257,7 @@ Shader "arktoon/Fade" {
                 float3 finalLight = lerp(indirectLighting,directLighting,directContribution)+coloredLight;
 
                 #ifdef USE_SHADE_TEXTURE
-                    #ifdef USE_SHADOW_MIX
-                        float3 shadeMixValue = finalLight;
-                    #else
-                        float3 shadeMixValue = directLighting;
-                    #endif
+                    float3 shadeMixValue = lerp(directLighting, finalLight, _ShadowPlanBDefaultShadowMix);
                     #ifdef USE_CUSTOM_SHADOW_TEXTURE
                         float4 _ShadowPlanBCustomShadowTexture_var = tex2D(_ShadowPlanBCustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanBCustomShadowTexture));
                         float3 shadowCustomTexture = _ShadowPlanBCustomShadowTexture_var.rgb * _ShadowPlanBCustomShadowTextureRGB.rgb;
@@ -234,7 +266,24 @@ Shader "arktoon/Fade" {
                         float3 Diff_HSV = CalculateHSV(Diffuse, _ShadowPlanBHueShiftFromBase, _ShadowPlanBSaturationFromBase, _ShadowPlanBValueFromBase);
                         float3 ShadeMap = Diff_HSV*shadeMixValue;
                     #endif
-                    float3 ToonedMap = (lerp(ShadeMap,Diffuse*finalLight,finalLight)/1.0);
+
+                    #ifdef USE_CUSTOM_SHADOW_2ND
+                        float ShadowborderMin2 = max(0, (_ShadowPlanB2border * _Shadowborder) - _ShadowPlanB2borderBlur/2);
+                        float ShadowborderMax2 = min(1, (_ShadowPlanB2border * _Shadowborder) + _ShadowPlanB2borderBlur/2);
+                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));
+                        #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
+                            float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));
+                            float3 shadowCustomTexture2 = _ShadowPlanB2CustomShadowTexture_var.rgb * _ShadowPlanB2CustomShadowTextureRGB.rgb;
+                            float3 ShadeMap2 = shadowCustomTexture2*shadeMixValue;
+                        #else
+                            float3 Diff_HSV2 = CalculateHSV(Diffuse, _ShadowPlanB2HueShiftFromBase, _ShadowPlanB2SaturationFromBase, _ShadowPlanB2ValueFromBase);
+                            float3 ShadeMap2 = Diff_HSV2*shadeMixValue;
+                        #endif
+                        ShadeMap = lerp(ShadeMap2,ShadeMap,directContribution2);
+                    #endif
+
+                    finalLight = lerp(ShadeMap,directLighting,directContribution)+coloredLight;
+                    float3 ToonedMap = lerp(ShadeMap,Diffuse*finalLight,finalLight);
                 #else
                     float3 ToonedMap = Diffuse*finalLight;
                 #endif

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -25,7 +25,7 @@ Shader "arktoon/Fade" {
         [Toggle(USE_SHADOW_STEPS)]_ShadowUseStep ("[Shadow] use step", Float ) = 0
         _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
         // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
-        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = １
+        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 1
         // Plan B
         [Toggle(USE_SHADE_TEXTURE)]_ShadowPlanBUsePlanB ("[Plan B] Use Plan B", Float ) = 0
         _ShadowPlanBDefaultShadowMix ("[Plan B] Shadow mix", Range(0, 1)) = 1
@@ -232,11 +232,13 @@ Shader "arktoon/Fade" {
                 float ShadowborderMin = max(0, _Shadowborder - _ShadowborderBlur/2);
                 float ShadowborderMax = min(1, _Shadowborder + _ShadowborderBlur/2);
 
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
+                float grayscaleDirectLighting2 = (((dot(lightDirection,normalDirection)*0.5+0.5)*grayscalelightcolor) + dot(ShadeSH9Normal( normalDirection ),grayscale_vector));
+                float remappedLight2 = ((grayscaleDirectLighting2-bottomIndirectLighting)/lightDifference);
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight2) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
 
                 float selfShade = saturate(dot(lightDirection,normalDirection)+1+_OtherShadowAdjust);
                 float otherShadow = saturate(saturate((attenuation-0.5)*2)+(1-selfShade)*_OtherShadowBorderSharpness);
-                directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())))));
+                directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())*1.5))));
 
                 #ifdef USE_SHADOW_STEPS
                     directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
@@ -270,7 +272,7 @@ Shader "arktoon/Fade" {
                     #ifdef USE_CUSTOM_SHADOW_2ND
                         float ShadowborderMin2 = max(0, (_ShadowPlanB2border * _Shadowborder) - _ShadowPlanB2borderBlur/2);
                         float ShadowborderMax2 = min(1, (_ShadowPlanB2border * _Shadowborder) + _ShadowPlanB2borderBlur/2);
-                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));
+                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate((remappedLight+remappedLight2)/2) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));  // /2の部分をパラメーターにしたい
                         #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
                             float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));
                             float3 shadowCustomTexture2 = _ShadowPlanB2CustomShadowTexture_var.rgb * _ShadowPlanB2CustomShadowTextureRGB.rgb;

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -148,58 +148,8 @@ Shader "arktoon/Fade" {
             uniform float4 _ShadowCapColor;
             uniform float _ShadowCapNormalMix;
 
-            struct VertexInput {
-                float4 vertex : POSITION;
-                float3 normal : NORMAL;
-                float4 tangent : TANGENT;
-                float2 texcoord0 : TEXCOORD0;
-            };
-            struct VertexOutput {
-                float4 pos : SV_POSITION;
-                float2 uv0 : TEXCOORD0;
-                float4 posWorld : TEXCOORD1;
-                float3 normalDir : TEXCOORD2;
-                float3 tangentDir : TEXCOORD3;
-                float3 bitangentDir : TEXCOORD4;
-                float3 ambient : TEXCOORD6;
-                float3 ambientAtten : TEXCOORD7;
-                LIGHTING_COORDS(5,6)
-                UNITY_FOG_COORDS(7)
-            };
-            VertexOutput vert (VertexInput v) {
-                VertexOutput o = (VertexOutput)0;
-                o.uv0 = v.texcoord0;
-                o.normalDir = UnityObjectToWorldNormal(v.normal);
-                o.tangentDir = normalize( mul( unity_ObjectToWorld, float4( v.tangent.xyz, 0.0 ) ).xyz );
-                o.bitangentDir = normalize(cross(o.normalDir, o.tangentDir) * v.tangent.w);
-                o.posWorld = mul(unity_ObjectToWorld, v.vertex);
-                o.pos = UnityObjectToClipPos( v.vertex );
-                UNITY_TRANSFER_FOG(o,o.pos);
-                TRANSFER_VERTEX_TO_FRAGMENT(o)
+            // vert は arklude.cginc に移動
 
-                // 頂点ライティングが必要ば場合に取得
-                #if UNITY_SHOULD_SAMPLE_SH
-                    #if defined(VERTEXLIGHT_ON)
-                        o.ambient = Shade4PointLights(
-                            unity_4LightPosX0, unity_4LightPosY0, unity_4LightPosZ0,
-                            unity_LightColor[0].rgb, unity_LightColor[1].rgb,
-                            unity_LightColor[2].rgb, unity_LightColor[3].rgb,
-                            unity_4LightAtten0, o.posWorld, o.normalDir
-                        );
-                        o.ambientAtten = Shade4PointLightsIndirect(
-                            unity_4LightPosX0, unity_4LightPosY0, unity_4LightPosZ0,
-                            unity_LightColor[0].rgb, unity_LightColor[1].rgb,
-                            unity_LightColor[2].rgb, unity_LightColor[3].rgb,
-                            unity_4LightAtten0, o.posWorld, o.normalDir
-                        );
-                    #else
-                        o.ambient = o.ambientAtten = 0;
-                    #endif
-                #else
-                    o.ambient = o.ambientAtten = 0;
-                #endif
-                return o;
-            }
             float4 frag(VertexOutput i) : COLOR {
                 i.normalDir = normalize(i.normalDir);
                 float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir);
@@ -239,9 +189,8 @@ Shader "arktoon/Fade" {
                 float topIndirectLighting = dot(ShadeSH9Plus,grayscale_vector);
                 float lightDifference = ((topIndirectLighting+grayscalelightcolor)-bottomIndirectLighting);
                 float remappedLight = ((grayscaleDirectLighting-bottomIndirectLighting)/lightDifference);
-                float node_4614 = 0.0;
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
-                float directContribution = (1.0 - ((1.0 - saturate((node_4614 + ( (saturate(remappedLight) - _ShadowborderMin) * (1.0 - node_4614) ) / (_ShadowborderMax - _ShadowborderMin)))) * _ShadowStrengthMask_var * _ShadowStrength));
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - _ShadowborderMin)) / (_ShadowborderMax - _ShadowborderMin))) * _ShadowStrengthMask_var * _ShadowStrength);
 
                 // 頂点ライティングを処理
 				float3 lightContribution = lerp(i.ambient, i.ambientAtten, 1-_PointShadowStrength);
@@ -392,7 +341,6 @@ Shader "arktoon/Fade" {
                 o.tangentDir = normalize( mul( unity_ObjectToWorld, float4( v.tangent.xyz, 0.0 ) ).xyz );
                 o.bitangentDir = normalize(cross(o.normalDir, o.tangentDir) * v.tangent.w);
                 o.posWorld = mul(unity_ObjectToWorld, v.vertex);
-                float3 lightColor = _LightColor0.rgb;
                 o.pos = UnityObjectToClipPos( v.vertex );
                 UNITY_TRANSFER_FOG(o,o.pos);
                 TRANSFER_VERTEX_TO_FRAGMENT(o)
@@ -435,7 +383,7 @@ Shader "arktoon/Fade" {
                 float3 directContribution = (1.0 - (1.0 - saturate(saturate(lightContribution))));
                 float _ShadowStrengthMask_var = tex2D(_ShadowStrengthMask, TRANSFORM_TEX(i.uv0, _ShadowStrengthMask));
                 float3 finalLight = saturate(directContribution + ((1 - (_PointShadowStrength * _ShadowStrengthMask_var)) * attenuation));
-                float3 coloredLight = lerp(0, _LightColor0.rgb, finalLight);
+                float3 coloredLight = lightColor*finalLight;
 
                 #ifdef USE_MATCAP
                     float3 normalDirectionMatcap = normalize(mul( float3(normalLocal.r*_MatcapNormalMix,normalLocal.g*_MatcapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
@@ -443,7 +391,7 @@ Shader "arktoon/Fade" {
                     float4 _MatcapTexture_var = tex2D(_MatcapTexture,TRANSFORM_TEX(transformMatcap, _MatcapTexture));
                     float4 _MatcapBlendMask_var = tex2D(_MatcapBlendMask,TRANSFORM_TEX(i.uv0, _MatcapBlendMask));
                     float3 matcap = ((_MatcapColor.rgb*_MatcapTexture_var.rgb)*_MatcapBlendMask_var.rgb*_MatcapBlend);
-                    matcap = min(matcap, matcap * lerp(float3(0,0,0), coloredLight, _MatcapShadeMix));
+                    matcap = min(matcap, matcap * (coloredLight * _MatcapShadeMix));
                 #else
                     float3 matcap = float3(0,0,0);
                 #endif
@@ -452,7 +400,7 @@ Shader "arktoon/Fade" {
                     float _RimBlendMask_var = tex2D(_RimBlendMask, TRANSFORM_TEX(i.uv0, _RimBlendMask));
                     float4 _RimTexture_var = tex2D(_RimTexture,TRANSFORM_TEX(i.uv0, _RimTexture));
                     float3 RimLight = (lerp( _RimTexture_var.rgb, Diffuse, _RimUseBaseTexture )*pow(1.0-max(0,dot(normalDirection, viewDirection)),_RimFresnelPower)*_RimBlend*_RimColor.rgb*_RimBlendMask_var);
-                    RimLight = min(RimLight, RimLight * lerp(float3(0,0,0), coloredLight, _RimShadeMix));
+                    RimLight = min(RimLight, RimLight * (coloredLight * _RimShadeMix));
                 #else
                     float3 RimLight = float3(0,0,0);
                 #endif

--- a/Assets/arktoon Shaders/Shaders/Fade.shader
+++ b/Assets/arktoon Shaders/Shaders/Fade.shader
@@ -25,7 +25,7 @@ Shader "arktoon/Fade" {
         [Toggle(USE_SHADOW_STEPS)]_ShadowUseStep ("[Shadow] use step", Float ) = 0
         _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
         // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
-        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.25
+        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = １
         // Plan B
         [Toggle(USE_SHADE_TEXTURE)]_ShadowPlanBUsePlanB ("[Plan B] Use Plan B", Float ) = 0
         _ShadowPlanBDefaultShadowMix ("[Plan B] Shadow mix", Range(0, 1)) = 1

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -272,10 +272,10 @@ Shader "arktoon/Opaque" {
                         #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
                             float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));
                             float3 shadowCustomTexture2 = _ShadowPlanB2CustomShadowTexture_var.rgb * _ShadowPlanB2CustomShadowTextureRGB.rgb;
-                            float3 ShadeMap2 = shadowCustomTexture*shadeMixValue;
+                            float3 ShadeMap2 = shadowCustomTexture2*shadeMixValue;
                         #else
                             float3 Diff_HSV2 = CalculateHSV(Diffuse, _ShadowPlanB2HueShiftFromBase, _ShadowPlanB2SaturationFromBase, _ShadowPlanB2ValueFromBase);
-                            float3 ShadeMap2 = Diff_HSV*shadeMixValue;
+                            float3 ShadeMap2 = Diff_HSV2*shadeMixValue;
                         #endif
                         ShadeMap = lerp(ShadeMap2,ShadeMap,directContribution2);
                     #endif

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -29,7 +29,7 @@ Shader "arktoon/Opaque" {
         [Toggle(USE_CUSTOM_SHADOW_TEXTURE)] _ShadowPlanBUseCustomShadowTexture ("[Plan B] Use Custom Shadow Texture", Float ) = 0
         _ShadowPlanBHueShiftFromBase ("[Plan B] Hue Shift From Base", Range(-1, 1)) = 0
         _ShadowPlanBSaturationFromBase ("[Plan B] Saturation From Base", Range(0, 2)) = 1
-        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 0
+        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 1
         _ShadowPlanBCustomShadowTexture ("[Plan B] Custom Shadow Texture", 2D) = "black" {}
         _ShadowPlanBCustomShadowTextureRGB ("[Plan B] Custom Shadow Texture RGB", Color) = (1,1,1,1)
         // Gloss

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -24,7 +24,7 @@ Shader "arktoon/Opaque" {
         [Toggle(USE_SHADOW_STEPS)]_ShadowUseStep ("[Shadow] use step", Float ) = 0
         _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
         // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
-        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.25
+        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 1
         // Plan B
         [Toggle(USE_SHADE_TEXTURE)]_ShadowPlanBUsePlanB ("[Plan B] Use Plan B", Float ) = 0
         _ShadowPlanBDefaultShadowMix ("[Plan B] Shadow mix", Range(0, 1)) = 1

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -266,8 +266,8 @@ Shader "arktoon/Opaque" {
                     #endif
 
                     #ifdef USE_CUSTOM_SHADOW_2ND
-                        float ShadowborderMin2 = max(0, _ShadowPlanB2border - _ShadowPlanB2borderBlur/2);
-                        float ShadowborderMax2 = min(1, _ShadowPlanB2border + _ShadowPlanB2borderBlur/2);
+                        float ShadowborderMin2 = max(0, (_ShadowPlanB2border * _Shadowborder) - _ShadowPlanB2borderBlur/2);
+                        float ShadowborderMax2 = min(1, (_ShadowPlanB2border * _Shadowborder) + _ShadowPlanB2borderBlur/2);
                         float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));
                         #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
                             float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));

--- a/Assets/arktoon Shaders/Shaders/Opaque.shader
+++ b/Assets/arktoon Shaders/Shaders/Opaque.shader
@@ -233,11 +233,13 @@ Shader "arktoon/Opaque" {
                 float ShadowborderMin = max(0, _Shadowborder - _ShadowborderBlur/2);
                 float ShadowborderMax = min(1, _Shadowborder + _ShadowborderBlur/2);
 
-                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
+                float grayscaleDirectLighting2 = (((dot(lightDirection,normalDirection)*0.5+0.5)*grayscalelightcolor) + dot(ShadeSH9Normal( normalDirection ),grayscale_vector));
+                float remappedLight2 = ((grayscaleDirectLighting2-bottomIndirectLighting)/lightDifference);
+                float directContribution = 1.0 - ((1.0 - saturate(( (saturate(remappedLight2) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
 
                 float selfShade = saturate(dot(lightDirection,normalDirection)+1+_OtherShadowAdjust);
                 float otherShadow = saturate(saturate((attenuation-0.5)*2)+(1-selfShade)*_OtherShadowBorderSharpness);
-                directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())))));
+                directContribution = lerp(0, directContribution, saturate(1-((1-otherShadow) * saturate(dot(lightColor,grayscale_for_light())*1.5))));
 
                 #ifdef USE_SHADOW_STEPS
                     directContribution = min(1,floor(directContribution * _ShadowSteps) / (_ShadowSteps - 1));
@@ -271,7 +273,7 @@ Shader "arktoon/Opaque" {
                     #ifdef USE_CUSTOM_SHADOW_2ND
                         float ShadowborderMin2 = max(0, (_ShadowPlanB2border * _Shadowborder) - _ShadowPlanB2borderBlur/2);
                         float ShadowborderMax2 = min(1, (_ShadowPlanB2border * _Shadowborder) + _ShadowPlanB2borderBlur/2);
-                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate(remappedLight) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));
+                        float directContribution2 = 1.0 - ((1.0 - saturate(( (saturate((remappedLight+remappedLight2)/2) - ShadowborderMin2)) / (ShadowborderMax2 - ShadowborderMin2))));  // /2の部分をパラメーターにしたい
                         #ifdef USE_CUSTOM_SHADOW_TEXTURE_2ND
                             float4 _ShadowPlanB2CustomShadowTexture_var = tex2D(_ShadowPlanB2CustomShadowTexture,TRANSFORM_TEX(i.uv0, _ShadowPlanB2CustomShadowTexture));
                             float3 shadowCustomTexture2 = _ShadowPlanB2CustomShadowTexture_var.rgb * _ShadowPlanB2CustomShadowTextureRGB.rgb;


### PR DESCRIPTION
 - 2陰を追加
 - 陰の方式をLambert→Half-Lambertへ変更
 - Shadow borderの指定方法を少し変更
　→Begin（開始位置） End（終了位置）式ではなく、Border（位置）とBlur（ぼかし量）で指定
　→内部で計算しているだけである。
 - 他MeshからのShadeに対してはなるたけBorderを影響しないようにした