### PR TITLE
Test double stencil reader

### DIFF
--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -23,6 +23,12 @@ namespace ArktoonShaders
         MaterialProperty BumpScale;
         MaterialProperty EmissionMap;
         MaterialProperty EmissionColor;
+        MaterialProperty BaseTextureSecondary;
+        MaterialProperty BaseColorSecondary;
+        MaterialProperty NormalmapSecondary;
+        MaterialProperty BumpScaleSecondary;
+        MaterialProperty EmissionMapSecondary;
+        MaterialProperty EmissionColorSecondary;
         MaterialProperty UseEmissionParallax;
         MaterialProperty EmissionParallaxColor;
         MaterialProperty EmissionParallaxTex;
@@ -110,6 +116,8 @@ namespace ArktoonShaders
         MaterialProperty ShadowCapTexture;
         MaterialProperty StencilNumber;
         MaterialProperty StencilCompareAction;
+        MaterialProperty StencilNumberSecondary;
+        MaterialProperty StencilCompareActionSecondary;
         MaterialProperty StencilMaskTex;
         MaterialProperty StencilMaskAdjust;
         MaterialProperty UseDoubleSided;
@@ -143,6 +151,7 @@ namespace ArktoonShaders
             bool isCutout = shader.name.Contains("Cutout");
             bool isStencilWriter = shader.name.Contains("Stencil/Writer");
             bool isStencilReader = shader.name.Contains("Stencil/Reader");
+            bool isStencilReaderDouble = shader.name.Contains("Stencil/Reader/Double");
             bool isStencilWriterMask = shader.name.Contains("Stencil/WriterMask");
             bool isRefracted = shader.name.Contains("Refracted");
 
@@ -153,6 +162,12 @@ namespace ArktoonShaders
             BumpScale = FindProperty("_BumpScale", props);
             EmissionMap = FindProperty("_EmissionMap", props);
             EmissionColor = FindProperty("_EmissionColor", props);
+            if(isStencilReaderDouble) BaseTextureSecondary = FindProperty("_MainTexSecondary", props);
+            if(isStencilReaderDouble) BaseColorSecondary = FindProperty("_ColorSecondary", props);
+            if(isStencilReaderDouble) NormalmapSecondary = FindProperty("_BumpMapSecondary", props);
+            if(isStencilReaderDouble) BumpScaleSecondary = FindProperty("_BumpScaleSecondary", props);
+            if(isStencilReaderDouble) EmissionMapSecondary = FindProperty("_EmissionMapSecondary", props);
+            if(isStencilReaderDouble) EmissionColorSecondary = FindProperty("_EmissionColorSecondary", props);
             UseEmissionParallax = FindProperty("_UseEmissionParallax", props);
             EmissionParallaxColor = FindProperty("_EmissionParallaxColor", props);
             EmissionParallaxTex = FindProperty("_EmissionParallaxTex", props);
@@ -242,6 +257,8 @@ namespace ArktoonShaders
             if(isStencilWriterMask) StencilMaskTex = FindProperty("_StencilMaskTex", props);
             if(isStencilWriterMask) StencilMaskAdjust = FindProperty("_StencilMaskAdjust", props);
             if(isStencilReader) StencilCompareAction = FindProperty("_StencilCompareAction", props);
+            if(isStencilReaderDouble) StencilNumberSecondary = FindProperty("_StencilNumberSecondary", props);
+            if(isStencilReaderDouble) StencilCompareActionSecondary = FindProperty("_StencilCompareActionSecondary", props);
             UseDoubleSided = FindProperty("_UseDoubleSided", props);
             DoubleSidedFlipBackfaceNormal = FindProperty("_DoubleSidedFlipBackfaceNormal", props);
             DoubleSidedBackfaceLightIntensity = FindProperty("_DoubleSidedBackfaceLightIntensity", props);
@@ -281,6 +298,17 @@ namespace ArktoonShaders
                     }
                     if(isFade) materialEditor.ShaderProperty(ZWrite, "ZWrite");
                     EditorGUI.indentLevel --;
+                }
+                // Secondary Common
+                if(isStencilReaderDouble) {
+                    UIHelper.ShurikenHeader("Secondary Common");
+                    {
+                        EditorGUI.indentLevel ++;
+                        materialEditor.TexturePropertySingleLine(new GUIContent("Main Texture", "Base Color Texture (RGB)"), BaseTextureSecondary, BaseColorSecondary);
+                        materialEditor.TexturePropertySingleLine(new GUIContent("Normal Map", "Normal Map (RGB)"), NormalmapSecondary, BumpScaleSecondary);
+                        materialEditor.TexturePropertySingleLine(new GUIContent("Emission", "Emission (RGB)"), EmissionMapSecondary, EmissionColorSecondary);
+                        EditorGUI.indentLevel --;
+                    }
                 }
 
                 // Refraction
@@ -517,8 +545,21 @@ namespace ArktoonShaders
                     UIHelper.ShurikenHeader("Stencil Reader");
                     {
                         EditorGUI.indentLevel++;
-                        materialEditor.ShaderProperty(StencilNumber,"Number");
-                        materialEditor.ShaderProperty(StencilCompareAction,"Compare Action");
+                        if(isStencilReaderDouble) {
+                            EditorGUILayout.LabelField("Primary", EditorStyles.boldLabel);
+                            EditorGUI.indentLevel++;
+                            materialEditor.ShaderProperty(StencilNumber,"Number");
+                            materialEditor.ShaderProperty(StencilCompareAction,"Compare Action");
+                            EditorGUI.indentLevel--;
+                            EditorGUILayout.LabelField("Secondary", EditorStyles.boldLabel);
+                            EditorGUI.indentLevel++;
+                            materialEditor.ShaderProperty(StencilNumberSecondary,"Number");
+                            materialEditor.ShaderProperty(StencilCompareActionSecondary,"Compare Action");
+                            EditorGUI.indentLevel--;
+                        } else {
+                            materialEditor.ShaderProperty(StencilNumber,"Number");
+                            materialEditor.ShaderProperty(StencilCompareAction,"Compare Action");
+                        }
                         EditorGUI.indentLevel--;
                     }
                 }

--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -120,6 +120,7 @@ namespace ArktoonShaders
         MaterialProperty StencilCompareActionSecondary;
         MaterialProperty StencilMaskTex;
         MaterialProperty StencilMaskAdjust;
+        MaterialProperty StencilMaskAlphaDither;
         MaterialProperty UseDoubleSided;
         MaterialProperty DoubleSidedFlipBackfaceNormal;
         MaterialProperty DoubleSidedBackfaceLightIntensity;
@@ -256,6 +257,7 @@ namespace ArktoonShaders
             if(isStencilWriter || isStencilReader) StencilNumber = FindProperty("_StencilNumber", props);
             if(isStencilWriterMask) StencilMaskTex = FindProperty("_StencilMaskTex", props);
             if(isStencilWriterMask) StencilMaskAdjust = FindProperty("_StencilMaskAdjust", props);
+            if(isStencilWriterMask) StencilMaskAlphaDither = FindProperty("_StencilMaskAlphaDither", props);
             if(isStencilReader) StencilCompareAction = FindProperty("_StencilCompareAction", props);
             if(isStencilReaderDouble) StencilNumberSecondary = FindProperty("_StencilNumberSecondary", props);
             if(isStencilReaderDouble) StencilCompareActionSecondary = FindProperty("_StencilCompareActionSecondary", props);
@@ -535,6 +537,7 @@ namespace ArktoonShaders
                         materialEditor.ShaderProperty(StencilNumber,"Number");
                         if(isStencilWriterMask) materialEditor.ShaderProperty(StencilMaskTex, "Mask Texture");
                         if(isStencilWriterMask) materialEditor.ShaderProperty(StencilMaskAdjust, "Mask Adjust");
+                        if(isStencilWriterMask) materialEditor.ShaderProperty(StencilMaskAlphaDither, "Alpha(Dither)");
                         EditorGUI.indentLevel--;
                     }
                 }

--- a/Assets/arktoon Shaders/Editor/ArktoonManager.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonManager.cs
@@ -12,7 +12,7 @@ namespace ArktoonShaders
     {
         static string url = "https://api.github.com/repos/synqark/Arktoon-Shaders/releases/latest";
         static UnityWebRequest www;
-        static string version = "0.9.6.0";
+        static string version = "0.9.8.0";
 
         [DidReloadScripts(0)]
         static void CheckVersion ()

--- a/Assets/arktoon Shaders/Shaders/StencilReaderDoubleFadeFade.shader
+++ b/Assets/arktoon Shaders/Shaders/StencilReaderDoubleFadeFade.shader
@@ -1,0 +1,354 @@
+// Copyright (c) 2018 synqark
+//
+// This code and repos（https://github.com/synqark/Arktoon-Shader) is under MIT licence, see LICENSE
+//
+// 本コードおよびリポジトリ（https://github.com/synqark/Arktoon-Shader) は MIT License を使用して公開しています。
+// 詳細はLICENSEか、https://opensource.org/licenses/mit-license.php を参照してください。
+Shader "arktoon/Stencil/Reader/Double/FadeFade" {
+    Properties {
+        // Double Sided
+        [Toggle(DOUBLE_SIDED)]_UseDoubleSided ("Double Sided", Float ) = 0
+        [Toggle]_DoubleSidedFlipBackfaceNormal ("Flip backface normal", Float ) = 0
+        _DoubleSidedBackfaceLightIntensity ("Backface Light intensity", Range(0, 1) ) = 0.5
+        [KeywordEnum(None, Front, Back)]_ShadowCasterCulling("[hidden] Shadow Caster Culling", Int) = 2 // Default Back
+        [Enum(Off, 0, On, 1)]_ZWrite("ZWrite", Float) = 0
+        // Common
+        _MainTex ("[Common] Base Texture", 2D) = "white" {}
+        _Color ("[Common] Base Color", Color) = (1,1,1,1)
+        _BumpMap ("[Common] Normal map", 2D) = "bump" {}
+        _BumpScale ("[Common] Normal scale", Range(0,2)) = 1
+        _EmissionMap ("[Common] Emission map", 2D) = "white" {}
+        _EmissionColor ("[Common] Emission Color", Color) = (0,0,0,1)
+        // Secondary Common
+        _MainTexSecondary ("[CommonSecondary] Base Texture", 2D) = "white" {}
+        _ColorSecondary ("[CommonSecondary] Base Color", Color) = (1,1,1,1)
+        _BumpMapSecondary ("[Common] Normal map", 2D) = "bump" {}
+        _BumpScaleSecondary ("[Common] Normal scale", Range(0,2)) = 1
+        _EmissionMapSecondary ("[Common] Emission map", 2D) = "white" {}
+        _EmissionColorSecondary ("[Common] Emission Color", Color) = (0,0,0,1)
+        // Emission Parallax
+        [Toggle(USE_EMISSION_PARALLLAX)]_UseEmissionParallax ("[Emission Parallax] Use Emission Parallax", Float ) = 0
+        _EmissionParallaxTex ("[Emission Parallax] Texture", 2D ) = "black" {}
+        _EmissionParallaxColor ("[Emission Parallax] Color", Color ) = (1,1,1,1)
+        _EmissionParallaxMask ("[Emission Parallax] Emission Mask", 2D ) = "white" {}
+        _EmissionParallaxDepth ("[Emission Parallax] Depth", Range(-1, 1) ) = 0
+        _EmissionParallaxDepthMask ("[Emission Parallax] Depth Mask", 2D ) = "white" {}
+        [Toggle]_EmissionParallaxDepthMaskInvert ("[Emission Parallax] Invert Depth Mask", Float ) = 0
+        // Shadow (received from DirectionalLight, other Indirect(baked) Lights, including SH)
+        _Shadowborder ("[Shadow] border ", Range(0, 1)) = 0.6
+        _ShadowborderBlur ("[Shadow] border Blur", Range(0, 1)) = 0.05
+        _ShadowborderBlurMask ("[Shadow] border Blur Mask", 2D) = "white" {}
+        _ShadowStrength ("[Shadow] Strength", Range(0, 1)) = 0.5
+        _ShadowStrengthMask ("[Shadow] Strength Mask", 2D) = "white" {}
+        _ShadowIndirectIntensity ("[Shadow] Indirect face Intensity", Range(0,0.5)) = 0.25
+        // Shadow steps
+        [Toggle]_ShadowUseStep ("[Shadow] use step", Float ) = 0
+        _ShadowSteps("[Shadow] steps between borders", Range(2, 10)) = 4
+        // PointShadow (received from Point/Spot Lights as Pixel/Vertex Lights)
+        _PointAddIntensity ("[PointShadow] Light Intensity", Range(0,1)) = 1
+        _PointShadowStrength ("[PointShadow] Strength", Range(0, 1)) = 0.5
+        _PointShadowborder ("[PointShadow] border ", Range(0, 1)) = 0.5
+        _PointShadowborderBlur ("[PointShadow] border Blur", Range(0, 1)) = 0.01
+        _PointShadowborderBlurMask ("[PointShadow] border Blur Mask", 2D) = "white" {}
+        [Toggle]_PointShadowUseStep ("[PointShadow] use step", Float ) = 0
+        _PointShadowSteps("[PointShadow] steps between borders", Range(2, 10)) = 2
+        // Plan B
+        [Toggle(USE_SHADE_TEXTURE)]_ShadowPlanBUsePlanB ("[Plan B] Use Plan B", Float ) = 0
+        _ShadowPlanBDefaultShadowMix ("[Plan B] Shadow mix", Range(0, 1)) = 1
+        [Toggle(USE_CUSTOM_SHADOW_TEXTURE)] _ShadowPlanBUseCustomShadowTexture ("[Plan B] Use Custom Shadow Texture", Float ) = 0
+        [PowerSlider(2.0)]_ShadowPlanBHueShiftFromBase ("[Plan B] Hue Shift From Base", Range(-0.5, 0.5)) = 0
+        _ShadowPlanBSaturationFromBase ("[Plan B] Saturation From Base", Range(0, 2)) = 1
+        _ShadowPlanBValueFromBase ("[Plan B] Value From Base", Range(0, 2)) = 1
+        _ShadowPlanBCustomShadowTexture ("[Plan B] Custom Shadow Texture", 2D) = "black" {}
+        _ShadowPlanBCustomShadowTextureRGB ("[Plan B] Custom Shadow Texture RGB", Color) = (1,1,1,1)
+        // ShadowPlanB-2
+        [Toggle(USE_CUSTOM_SHADOW_2ND)]_CustomShadow2nd ("[Plan B-2] CustomShadow2nd", Float ) = 0
+        _ShadowPlanB2border ("[Plan B-2] border ", Range(0, 1)) = 0.55
+        _ShadowPlanB2borderBlur ("[Plan B-2] border Blur", Range(0, 1)) = 0.55
+        [Toggle(USE_CUSTOM_SHADOW_TEXTURE_2ND)] _ShadowPlanB2UseCustomShadowTexture ("[Plan B-2] Use Custom Shadow Texture", Float ) = 0
+        [PowerSlider(2.0)]_ShadowPlanB2HueShiftFromBase ("[Plan B-2] Hue Shift From Base", Range(-0.5, 0.5)) = 0
+        _ShadowPlanB2SaturationFromBase ("[Plan B-2] Saturation From Base", Range(0, 2)) = 1
+        _ShadowPlanB2ValueFromBase ("[Plan B-2] Value From Base", Range(0, 2)) = 1
+        _ShadowPlanB2CustomShadowTexture ("[Plan B-2] Custom Shadow Texture", 2D) = "black" {}
+        _ShadowPlanB2CustomShadowTextureRGB ("[Plan B-2] Custom Shadow Texture RGB", Color) = (1,1,1,1)
+        // Gloss
+        [Toggle(USE_GLOSS)]_UseGloss ("[Gloss] Enabled", Float) = 0
+        _GlossBlend ("[Gloss] Smoothness", Range(0, 1)) = 0.5
+        _GlossBlendMask ("[Gloss] Smoothness Mask", 2D) = "white" {}
+        _GlossPower ("[Gloss] Metallic", Range(0, 1)) = 0.5
+        _GlossColor ("[Gloss] Color", Color) = (1,1,1,1)
+        // Outline
+        [Toggle(USE_OUTLINE)]_UseOutline ("[Outline] Enabled", Float) = 0
+        _OutlineWidth ("[Outline] Width", Range(0, 20)) = 0.1
+        _OutlineMask ("[Outline] Outline Mask", 2D) = "white" {}
+        _OutlineCutoffRange ("[Outline] Cutoff Range", Range(0, 1)) = 0
+        _OutlineColor ("[Outline] Color", Color) = (0,0,0,1)
+        _OutlineShadeMix ("[Outline] Shade Mix", Range(0, 1)) = 0
+        _OutlineTextureColorRate ("[Outline] Texture Color Rate", Range(0, 1)) = 0.05
+        [Toggle(USE_OUTLINE_WIDTH_MASK)]_UseOutlineWidthMask ("[Outline] Use Width Mask", Float) = 0
+        _OutlineWidthMask ("[Outline] Outline Width Mask", 2D) = "white" {}
+        // MatCap
+        [KeywordEnum(Add, Lighten, Screen, Unused)] _MatcapBlendMode ("[MatCap] Blend Mode", Float) = 3
+        _MatcapBlend ("[MatCap] Blend", Range(0, 3)) = 1
+        _MatcapBlendMask ("[MatCap] Blend Mask", 2D) = "white" {}
+        _MatcapNormalMix ("[MatCap] Normal map mix", Range(0, 2)) = 1
+        _MatcapShadeMix ("[MatCap] Shade Mix", Range(0, 1)) = 0
+        _MatcapTexture ("[MatCap] Texture", 2D) = "black" {}
+        _MatcapColor ("[MatCap] Color", Color) = (1,1,1,1)
+        // Reflection
+        [Toggle(USE_REFLECTION)]_UseReflection ("[Reflection] Enabled", Float) = 0
+        [Toggle(USE_REFLECTION_PROBE)]_UseReflectionProbe ("[Reflection] Use Reflection Probe", Float) = 1
+        _ReflectionReflectionPower ("[Reflection] Reflection Power", Range(0, 1)) = 1
+        _ReflectionReflectionMask ("[Reflection] Reflection Mask", 2D) = "white" {}
+        _ReflectionNormalMix ("[Reflection] Normal Map Mix", Range(0,2)) = 1
+        _ReflectionShadeMix ("[Reflection] Shade Mix", Range(0, 1)) = 0
+        _ReflectionSuppressBaseColorValue ("[Reflection] Suppress Base Color", Range(0, 1)) = 1
+        _ReflectionCubemap ("[Reflection] Cubemap", Cube) = "" {}
+        // Rim
+        [Toggle(USE_RIM)]_UseRim ("[Rim] Enabled", Float) = 0
+        _RimBlend ("[Rim] Blend", Range(0, 3)) = 1
+        _RimBlendMask ("[Rim] Blend Mask", 2D) = "white" {}
+        _RimShadeMix("[Rim] Shade Mix", Range(0, 1)) = 0
+        [PowerSlider(3.0)]_RimFresnelPower ("[Rim] Fresnel Power", Range(0, 200)) = 1
+        _RimUpperSideWidth("[Rim] Upper width", Range(0, 1)) = 0
+        _RimColor ("[Rim] Color", Color) = (1,1,1,1)
+        _RimTexture ("[Rim] Texture", 2D) = "white" {}
+        [MaterialToggle] _RimUseBaseTexture ("[Rim] Use Base Texture", Float ) = 0
+        // ShadowCap
+        [KeywordEnum(Darken, Multiply, Light Shutter, Unused)] _ShadowCapBlendMode ("[ShadowCap] Blend Mode", Float) = 3
+        _ShadowCapBlend ("[ShadowCap] Blend", Range(0, 3)) = 1
+        _ShadowCapBlendMask ("[ShadowCap] Blend Mask", 2D) = "white" {}
+        _ShadowCapNormalMix ("[ShadowCap] Normal map mix", Range(0, 2)) = 1
+        _ShadowCapTexture ("[ShadowCap] Texture", 2D) = "white" {}
+        // Stencil(Reader)
+        _StencilNumber ("[StencilReader] Number", int) = 5
+        [Enum(UnityEngine.Rendering.CompareFunction)] _StencilCompareAction ("[StencilReader] Compare Action", int) = 6
+        _StencilNumberSecondary ("[StencilReaderSecondary] Number", int) = 5
+        [Enum(UnityEngine.Rendering.CompareFunction)] _StencilCompareActionSecondary ("[StencilReaderSecondary] Compare Action", int) = 6
+        // vertex color blend
+        _VertexColorBlendDiffuse ("[VertexColor] Blend to diffuse", Range(0,1)) = 0
+        _VertexColorBlendEmissive ("[VertexColor] Blend to emissive", Range(0,1)) = 0
+        // advanced tweaking
+        _OtherShadowAdjust ("[Advanced] Other Mesh Shadow Adjust", Range(-0.2, 0.2)) = -0.1
+        _OtherShadowBorderSharpness ("[Advanced] Other Mesh Shadow Border Sharpness", Range(1, 5)) = 3
+        // Per-vertex light switching
+        [Toggle(USE_VERTEX_LIGHT)]_UseVertexLight("[Advanced] Use Per-vertex Lighting", Float) = 1
+        // Light Sampling
+        [KeywordEnum(Arktoon, Cubed)]_LightSampling("[Light] Sampling Style", Float) = 0
+        // Legacy MatCap/ShadeCap Calculation
+        [Toggle(USE_POSITION_RELATED_CALC)]_UsePositionRelatedCalc ("[Mat/ShadowCap] Use Position Related Calc (Experimental)", Float) = 0
+    }
+    SubShader {
+        Tags {
+            "Queue"="Transparent"
+            "RenderType"="Transparent"
+        }
+        Pass {
+            Name "FORWARD_PRIMARY"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+            Cull Back
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite [_ZWrite]
+
+            Stencil {
+                Ref [_StencilNumber]
+                Comp [_StencilCompareAction]
+            }
+
+            CGPROGRAM
+            #pragma shader_feature USE_SHADE_TEXTURE
+            #pragma shader_feature USE_GLOSS
+            #pragma shader_feature USE_REFLECTION
+            #pragma shader_feature USE_REFLECTION_PROBE
+            #pragma shader_feature USE_RIM
+            #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
+            #pragma shader_feature USE_CUSTOM_SHADOW_2ND
+            #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE_2ND
+            #pragma shader_feature USE_VERTEX_LIGHT
+            #pragma shader_feature USE_OUTLINE
+            #pragma shader_feature USE_OUTLINE_WIDTH_MASK
+            #pragma shader_feature DOUBLE_SIDED
+            #pragma shader_feature USE_POSITION_RELATED_CALC
+            #pragma shader_feature USE_EMISSION_PARALLLAX
+
+            #pragma shader_feature _MATCAPBLENDMODE_UNUSED _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
+            #pragma shader_feature _SHADOWCAPBLENDMODE_UNUSED _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY _SHADOWCAPBLENDMODE_LIGHT_SHUTTER
+            #pragma shader_feature _LIGHTSAMPLING_ARKTOON _LIGHTSAMPLING_CUBED
+
+            #pragma vertex vert
+            #pragma geometry geom
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_fog
+            #pragma only_renderers d3d9 d3d11 glcore gles
+            #pragma target 4.0
+            #define ARKTOON_FADE
+
+            #include "cginc/arkludeDecl.cginc"
+            #include "cginc/arkludeOther.cginc"
+            #include "cginc/arkludeVertGeom.cginc"
+            #include "cginc/arkludeFrag.cginc"
+            ENDCG
+        }
+        Pass {
+            Name "FORWARD_DELTA_PRIMARY"
+            Tags {
+                "LightMode"="ForwardAdd"
+            }
+            Cull Back
+            Blend One One
+            ZWrite [_ZWrite]
+
+            Stencil {
+                Ref [_StencilNumber]
+                Comp [_StencilCompareAction]
+            }
+
+            CGPROGRAM
+            #pragma shader_feature USE_GLOSS
+            #pragma shader_feature USE_RIM
+            #pragma shader_feature USE_OUTLINE
+            #pragma shader_feature USE_OUTLINE_WIDTH_MASK
+            #pragma shader_feature DOUBLE_SIDED
+            #pragma shader_feature USE_POSITION_RELATED_CALC
+            #pragma shader_feature _MATCAPBLENDMODE_UNUSED _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
+            #pragma shader_feature _SHADOWCAPBLENDMODE_UNUSED _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY _SHADOWCAPBLENDMODE_LIGHT_SHUTTER
+
+            #pragma vertex vert
+            #pragma geometry geom
+            #pragma fragment frag
+            #pragma multi_compile_fwdadd
+            #pragma multi_compile_fog
+            #pragma only_renderers d3d9 d3d11 glcore gles
+            #pragma target 4.0
+            #define ARKTOON_FADE
+            #define ARKTOON_ADD
+
+            #include "cginc/arkludeDecl.cginc"
+            #include "cginc/arkludeOther.cginc"
+            #include "cginc/arkludeVertGeom.cginc"
+            #include "cginc/arkludeAdd.cginc"
+            ENDCG
+        }
+        Pass {
+            Name "FORWARD_SECONDARY"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+            Cull Back
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite [_ZWrite]
+
+            Stencil {
+                Ref [_StencilNumberSecondary]
+                Comp [_StencilCompareActionSecondary]
+            }
+
+            CGPROGRAM
+            #pragma shader_feature USE_SHADE_TEXTURE
+            #pragma shader_feature USE_GLOSS
+            #pragma shader_feature USE_REFLECTION
+            #pragma shader_feature USE_REFLECTION_PROBE
+            #pragma shader_feature USE_RIM
+            #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE
+            #pragma shader_feature USE_CUSTOM_SHADOW_2ND
+            #pragma shader_feature USE_CUSTOM_SHADOW_TEXTURE_2ND
+            #pragma shader_feature USE_VERTEX_LIGHT
+            #pragma shader_feature USE_OUTLINE
+            #pragma shader_feature USE_OUTLINE_WIDTH_MASK
+            #pragma shader_feature DOUBLE_SIDED
+            #pragma shader_feature USE_POSITION_RELATED_CALC
+            #pragma shader_feature USE_EMISSION_PARALLLAX
+
+            #pragma shader_feature _MATCAPBLENDMODE_UNUSED _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
+            #pragma shader_feature _SHADOWCAPBLENDMODE_UNUSED _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY _SHADOWCAPBLENDMODE_LIGHT_SHUTTER
+            #pragma shader_feature _LIGHTSAMPLING_ARKTOON _LIGHTSAMPLING_CUBED
+
+            #pragma vertex vert
+            #pragma geometry geom
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_fog
+            #pragma only_renderers d3d9 d3d11 glcore gles
+            #pragma target 4.0
+            #define ARKTOON_FADE
+            #define ARKTOON_SECONDARY
+
+            #include "cginc/arkludeDecl.cginc"
+            #include "cginc/arkludeOther.cginc"
+            #include "cginc/arkludeVertGeom.cginc"
+            #include "cginc/arkludeFrag.cginc"
+            ENDCG
+        }
+        Pass {
+            Name "FORWARD_DELTA_SECONDARY"
+            Tags {
+                "LightMode"="ForwardAdd"
+            }
+            Cull Back
+            Blend One One
+            ZWrite [_ZWrite]
+
+            Stencil {
+                Ref [_StencilNumberSecondary]
+                Comp [_StencilCompareActionSecondary]
+            }
+
+            CGPROGRAM
+            #pragma shader_feature USE_GLOSS
+            #pragma shader_feature USE_RIM
+            #pragma shader_feature USE_OUTLINE
+            #pragma shader_feature USE_OUTLINE_WIDTH_MASK
+            #pragma shader_feature DOUBLE_SIDED
+            #pragma shader_feature USE_POSITION_RELATED_CALC
+            #pragma shader_feature _MATCAPBLENDMODE_UNUSED _MATCAPBLENDMODE_ADD _MATCAPBLENDMODE_LIGHTEN _MATCAPBLENDMODE_SCREEN
+            #pragma shader_feature _SHADOWCAPBLENDMODE_UNUSED _SHADOWCAPBLENDMODE_DARKEN _SHADOWCAPBLENDMODE_MULTIPLY _SHADOWCAPBLENDMODE_LIGHT_SHUTTER
+
+            #pragma vertex vert
+            #pragma geometry geom
+            #pragma fragment frag
+            #pragma multi_compile_fwdadd
+            #pragma multi_compile_fog
+            #pragma only_renderers d3d9 d3d11 glcore gles
+            #pragma target 4.0
+            #define ARKTOON_FADE
+            #define ARKTOON_ADD
+            #define ARKTOON_SECONDARY
+
+            #include "cginc/arkludeDecl.cginc"
+            #include "cginc/arkludeOther.cginc"
+            #include "cginc/arkludeVertGeom.cginc"
+            #include "cginc/arkludeAdd.cginc"
+            ENDCG
+        }
+
+        // ------------------------------------------------------------------
+        //  Shadow rendering pass
+        Pass {
+            Name "SHADOWCASTER"
+            Tags { "LightMode" = "ShadowCaster" }
+
+            ZWrite On ZTest LEqual
+            Cull [_ShadowCasterCulling]
+
+            CGPROGRAM
+            #pragma target 3.0
+
+            // -------------------------------------
+
+            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
+            #pragma multi_compile_shadowcaster
+
+            #pragma vertex vertShadowCaster
+            #pragma fragment fragShadowCaster
+
+            #include "cginc/arkludeFadeShadowCaster.cginc"
+
+            ENDCG
+        }
+    }
+    FallBack "Standard"
+    CustomEditor "ArktoonShaders.ArktoonInspector"
+}

--- a/Assets/arktoon Shaders/Shaders/StencilReaderDoubleFadeFade.shader.meta
+++ b/Assets/arktoon Shaders/Shaders/StencilReaderDoubleFadeFade.shader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d892e826f730774797c3acfca1b43db
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/arktoon Shaders/Shaders/StencilWriterMaskTexture.shader
+++ b/Assets/arktoon Shaders/Shaders/StencilWriterMaskTexture.shader
@@ -118,6 +118,7 @@ Shader "arktoon/Stencil/WriterMask/Cutout" {
         _StencilNumber ("[StencilWriter] Number", int) = 5
         _StencilMaskTex ("[StencilWriter] Mask Texture", 2D) = "white" {}
         _StencilMaskAdjust ("[StencilWriter] Mask Texture Adjust", Range(0, 1)) = 0.5
+        _StencilMaskAlphaDither ("[StencilWriter] StencilAlpha(Dither)", Range(0, 1)) = 1.0
         // vertex color blend
         _VertexColorBlendDiffuse ("[VertexColor] Blend to diffuse", Range(0,1)) = 0
         _VertexColorBlendEmissive ("[VertexColor] Blend to emissive", Range(0,1)) = 0

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeAdd.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeAdd.cginc
@@ -4,7 +4,7 @@ float4 frag(VertexOutput i) : COLOR {
 
     float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir * lerp(1, i.faceSign, _DoubleSidedFlipBackfaceNormal));
     float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
-    float3 _BumpMap_var = UnpackScaleNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)), _BumpScale);
+    float3 _BumpMap_var = UnpackScaleNormal(tex2D(REF_BUMPMAP,TRANSFORM_TEX(i.uv0, REF_BUMPMAP)), REF_BUMPSCALE);
     float3 normalLocal = _BumpMap_var.rgb;
     float3 normalDirection = normalize(mul( normalLocal, tangentTransform )); // Perturbed normals
 
@@ -13,25 +13,25 @@ float4 frag(VertexOutput i) : COLOR {
     float3 halfDirection = normalize(viewDirection+lightDirection);
 
     UNITY_LIGHT_ATTENUATION(attenuation,i, i.posWorld.xyz);
-    float4 _MainTex_var = UNITY_SAMPLE_TEX2D(_MainTex, TRANSFORM_TEX(i.uv0, _MainTex));
-    float3 Diffuse = (_MainTex_var.rgb*_Color.rgb);
+    float4 _MainTex_var = UNITY_SAMPLE_TEX2D(REF_MAINTEX, TRANSFORM_TEX(i.uv0, REF_MAINTEX));
+    float3 Diffuse = (_MainTex_var.rgb*REF_COLOR.rgb);
     Diffuse = lerp(Diffuse, Diffuse * i.color,_VertexColorBlendDiffuse); // 頂点カラーを合成
 
     // アウトラインであればDiffuseとColorを混ぜる
     Diffuse = lerp(Diffuse, (Diffuse * _OutlineTextureColorRate + i.col * (1 - _OutlineTextureColorRate)), i.isOutline);
 
     #ifdef ARKTOON_CUTOUT
-        clip((_MainTex_var.a * _Color.a) - _CutoutCutoutAdjust);
+        clip((_MainTex_var.a * REF_COLOR.a) - _CutoutCutoutAdjust);
     #endif
 
     #if defined(ARKTOON_CUTOUT) || defined(ARKTOON_FADE)
         if (i.isOutline) {
-            float _OutlineMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_OutlineMask, _MainTex, TRANSFORM_TEX(i.uv0, _OutlineMask)).r;
+            float _OutlineMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_OutlineMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _OutlineMask)).r;
             clip(_OutlineMask_var.r - _OutlineCutoffRange);
         }
     #endif
 
-    fixed _PointShadowborderBlur_var = UNITY_SAMPLE_TEX2D_SAMPLER(_PointShadowborderBlurMask, _MainTex, TRANSFORM_TEX(i.uv0, _PointShadowborderBlurMask)).r * _PointShadowborderBlur;
+    fixed _PointShadowborderBlur_var = UNITY_SAMPLE_TEX2D_SAMPLER(_PointShadowborderBlurMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _PointShadowborderBlurMask)).r * _PointShadowborderBlur;
     float ShadowborderMin = max(0, _PointShadowborder - _PointShadowborderBlur_var/2);
     float ShadowborderMax = min(1, _PointShadowborder + _PointShadowborderBlur_var/2);
 
@@ -58,7 +58,7 @@ float4 frag(VertexOutput i) : COLOR {
             float2 transformShadowCap = (mul( UNITY_MATRIX_V, float4(normalDirectionShadowCap,0) ).xyz.rg*0.5+0.5);
         #endif
         float4 _ShadowCapTexture_var = tex2D(_ShadowCapTexture,TRANSFORM_TEX(transformShadowCap, _ShadowCapTexture));
-        float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, _MainTex, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
+        float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
         additionalContributionMultiplier *= (1.0 - ((1.0 - (_ShadowCapTexture_var.rgb))*_ShadowCapBlendMask_var.rgb)*_ShadowCapBlend);
     #endif
 
@@ -78,7 +78,7 @@ float4 frag(VertexOutput i) : COLOR {
     #endif
         // オプション：Gloss
         #ifdef USE_GLOSS
-            float _GlossBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_GlossBlendMask, _MainTex, TRANSFORM_TEX(i.uv0, _GlossBlendMask));
+            float _GlossBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_GlossBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _GlossBlendMask));
 
             float gloss = _GlossBlend * _GlossBlendMask_var;
             float perceptualRoughness = 1.0 - gloss;
@@ -126,7 +126,7 @@ float4 frag(VertexOutput i) : COLOR {
                 float2 transformShadowCap = (mul( UNITY_MATRIX_V, float4(normalDirectionShadowCap,0) ).xyz.rg*0.5+0.5);
             #endif
             float4 _ShadowCapTexture_var = tex2D(_ShadowCapTexture,TRANSFORM_TEX(transformShadowCap, _ShadowCapTexture));
-            float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, _MainTex, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
+            float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
             shadowcap = (1.0 - ((1.0 - (_ShadowCapTexture_var.rgb))*_ShadowCapBlendMask_var.rgb)*_ShadowCapBlend);
         #endif
 
@@ -144,14 +144,14 @@ float4 frag(VertexOutput i) : COLOR {
                 float2 transformMatcap = (mul( UNITY_MATRIX_V, float4(normalDirectionMatcap,0) ).xyz.rg*0.5+0.5);
             #endif
             float4 _MatcapTexture_var = tex2D(_MatcapTexture,TRANSFORM_TEX(transformMatcap, _MatcapTexture));
-            float4 _MatcapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_MatcapBlendMask, _MainTex, TRANSFORM_TEX(i.uv0, _MatcapBlendMask));
+            float4 _MatcapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_MatcapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _MatcapBlendMask));
             float3 matcapResult = ((_MatcapColor.rgb*_MatcapTexture_var.rgb)*_MatcapBlendMask_var.rgb*_MatcapBlend);
             matcap = min(matcapResult, matcapResult * (coloredLight * _MatcapShadeMix));
         #endif
 
         // オプション：Rim
         #ifdef USE_RIM
-            float _RimBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_RimBlendMask, _MainTex, TRANSFORM_TEX(i.uv0, _RimBlendMask));
+            float _RimBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_RimBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _RimBlendMask));
             float4 _RimTexture_var = tex2D(_RimTexture,TRANSFORM_TEX(i.uv0, _RimTexture));
             RimLight = (
                 lerp( _RimTexture_var.rgb, Diffuse, _RimUseBaseTexture )
@@ -188,7 +188,7 @@ float4 frag(VertexOutput i) : COLOR {
     #endif
 
     #ifdef ARKTOON_FADE
-        fixed4 finalRGBA = fixed4(finalColor * (_MainTex_var.a * _Color.a),0);
+        fixed4 finalRGBA = fixed4(finalColor * (_MainTex_var.a * REF_COLOR.a),0);
     #else
         fixed4 finalRGBA = fixed4(finalColor * 1,0);
     #endif

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeDecl.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeDecl.cginc
@@ -2,13 +2,36 @@
 #include "AutoLight.cginc"
 #include "Lighting.cginc"
 
-// Main, Normal, Emission
-UNITY_DECLARE_TEX2D(_MainTex); uniform float4 _MainTex_ST;
-uniform float4 _Color;
-uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
-uniform float _BumpScale;
-uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
-uniform float4 _EmissionColor;
+
+#if defined(ARKTOON_SECONDARY)
+    // Secondary
+    UNITY_DECLARE_TEX2D(_MainTexSecondary); uniform float4 _MainTexSecondary_ST;
+    uniform float4 _ColorSecondary;
+    uniform sampler2D _BumpMapSecondary; uniform float4 _BumpMapSecondary_ST;
+    uniform float _BumpScaleSecondary;
+    uniform sampler2D _EmissionMapSecondary; uniform float4 _EmissionMapSecondary_ST;
+    uniform float4 _EmissionColorSecondary;
+#   define REF_MAINTEX _MainTexSecondary
+#   define REF_COLOR _ColorSecondary
+#   define REF_BUMPMAP _BumpMapSecondary
+#   define REF_BUMPSCALE _BumpScaleSecondary
+#   define REF_EMISSIONMAP _EmissionMapSecondary
+#   define REF_EMISSIONCOLOR _EmissionColorSecondary
+#else
+    // Main, Normal, Emission
+    UNITY_DECLARE_TEX2D(_MainTex); uniform float4 _MainTex_ST;
+    uniform float4 _Color;
+    uniform sampler2D _BumpMap; uniform float4 _BumpMap_ST;
+    uniform float _BumpScale;
+    uniform sampler2D _EmissionMap; uniform float4 _EmissionMap_ST;
+    uniform float4 _EmissionColor;
+#   define REF_MAINTEX _MainTex
+#   define REF_COLOR _Color
+#   define REF_BUMPMAP _BumpMap
+#   define REF_BUMPSCALE _BumpScale
+#   define REF_EMISSIONMAP _EmissionMap
+#   define REF_EMISSIONCOLOR _EmissionColor
+#endif
 
 // Emission Parallax
 uniform float _UseEmissionParallax;

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeFragOnlyStencilWrite.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeFragOnlyStencilWrite.cginc
@@ -1,5 +1,7 @@
 uniform sampler2D _StencilMaskTex; uniform float4 _StencilMaskTex_ST;
 uniform float _StencilMaskAdjust;
+uniform float _StencilMaskAlphaDither;
+uniform sampler2D _DitherMaskLOD2D;
 
 float4 frag(VertexOutput i) : COLOR {
     // MainTex, Color, StencilMask情報をもとにClipするだけ
@@ -7,6 +9,13 @@ float4 frag(VertexOutput i) : COLOR {
     float4 _StencilMaskTex_var = tex2D(_StencilMaskTex,TRANSFORM_TEX(i.uv0, _StencilMaskTex));
 
     clip(min((_MainTex_var.a *_Color.a) - _CutoutCutoutAdjust, _StencilMaskTex_var - _StencilMaskAdjust));
+
+    // _DitherMaskLOD2Dを使って更にclipする
+    float4 pos = i.pos;
+    pos *= 0.25;
+    pos.y = frac(pos.y) * 0.0625;
+    pos.y += _StencilMaskAlphaDither * 0.9375;
+    clip(tex2D(_DitherMaskLOD2D, pos).a - 0.5);
 
     float4 finalRGBA = float4(0,0,0,0);
     return finalRGBA;


### PR DESCRIPTION
close #87 

・Unity 2017.4でビルドしなおしました。以前のバージョンは動作保証外とします。
・「Stencil/Reader/Double/FadeFade」バリエーションを追加しました。
　「2枚」書きます。それぞれPrimaryとSecondaryという名前になります。
　・PrimaryとSecondaryは殆どのプロパティを共有しています
　　「Main Texture」「Color」「Normal Map」「Emission」の４つはそれぞれ別で定義できます。
　　「Stencil Reader」で、PrimaryとSecondaryごとに設定を入力できます。
　・RenderQueueは3000なため、他のメッシュから影を受け取れないことに注意してください。(編集済)

・「Stencil/WriterMask/Cutout」の「Stencil Writer」で、Alphaスライダーを追加しました。
　これは、書き込むステンシルバッファにディザリング処理を施すため、疑似的な半透明ステンシルとして機能したいときに使用できます。

（「ディザリングをしたくない」「でもステンシルで抜かないところには影を落としたい」場合は、もはやシェーダーで手を打てないので、メッシュを複製してそれぞれReaderを使うか、単一のマテリアルで構成されたメッシュであれば、2枚目のマテリアルを定義するのが手っ取り早く、リッチな表現ができることを念頭に置いておいてください。）(編集済)
