### PR TITLE
Improve inspector look good of Pro skin

### DIFF
--- a/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
+++ b/Assets/arktoon Shaders/Editor/ArktoonInspector.cs
@@ -724,7 +724,7 @@ namespace ArktoonShaders
 
                 UIHelper.ShurikenHeader("Arktoon-Shaders");
                 style.alignment = TextAnchor.MiddleRight;
-                style.normal.textColor = Color.black;
+                style.normal.textColor = EditorGUIUtility.isProSkin ? Color.white : Color.black;
                 EditorGUILayout.LabelField("Your Version : " + localVersion, style);
 
                 if (!string.IsNullOrEmpty(remoteVersion))
@@ -733,7 +733,7 @@ namespace ArktoonShaders
                     Version remote_v = new Version(remoteVersion);
 
                     if(remote_v > local_v)  {
-                        style.normal.textColor = Color.blue;
+                        style.normal.textColor = EditorGUIUtility.isProSkin ? Color.cyan : Color.blue;
                         EditorGUILayout.LabelField("Remote Version : " + remoteVersion, style);
                         EditorGUILayout.BeginHorizontal( GUI.skin.box );
                         {


### PR DESCRIPTION
Difficult to read some characters with Pro skin.
I changed the color according to the skin.

-----

Proスキンでは以下のように黒背景に黒文字で文字が見えない
![bad_look1](https://user-images.githubusercontent.com/8447771/54111411-1e0b9680-4427-11e9-8cc9-b8a52a71d467.png)
![bad_look2](https://user-images.githubusercontent.com/8447771/54111416-1fd55a00-4427-11e9-9276-1348956265ee.png)

読みやすい文字色に変更しました
![good_look1](https://user-images.githubusercontent.com/8447771/54111479-485d5400-4427-11e9-9864-d52c52de04f5.png)
![good_look2](https://user-images.githubusercontent.com/8447771/54111485-4c897180-4427-11e9-907a-eebb56a91dc6.png)
