### PR TITLE
Fixed coloredLight_sum redefinition error.

### DIFF
--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeFrag.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeFrag.cginc
@@ -123,7 +123,7 @@ float4 frag(VertexOutput i) : COLOR {
         float3 coloredLight_1 = max(directContributionVertex.g * i.lightColor1 * i.ambientAttenuation.g, i.lightColor1 * i.ambientIndirect.g * (1-_PointShadowStrength));
         float3 coloredLight_2 = max(directContributionVertex.b * i.lightColor2 * i.ambientAttenuation.b, i.lightColor2 * i.ambientIndirect.b * (1-_PointShadowStrength));
         float3 coloredLight_3 = max(directContributionVertex.a * i.lightColor3 * i.ambientAttenuation.a, i.lightColor3 * i.ambientIndirect.a * (1-_PointShadowStrength));
-        float3 coloredLight_sum = (coloredLight_0 + coloredLight_1 + coloredLight_2 + coloredLight_3) * _PointAddIntensity;
+        coloredLight_sum = (coloredLight_0 + coloredLight_1 + coloredLight_2 + coloredLight_3) * _PointAddIntensity;
     }
 
     float3 finalLight = lerp(indirectLighting,directLighting,directContribution)+coloredLight_sum;


### PR DESCRIPTION
Removing the "if _UseVertexLight" block for optimization becomes a problem. If there is no point in redefining, please modify it.

最適化のために "if _UseVertexLight" ブロックを取り除くと再定義エラーが発生してしまいます。
この記述に特に理由がなければ修正して頂きたいです。