### PR TITLE
各種フラグメントシェーダーの最適化、バグ修正

### DIFF
--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeAdd.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeAdd.cginc
@@ -11,7 +11,7 @@ float4 frag(VertexOutput i) : COLOR {
     float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));
     float3 lightColor = _LightColor0.rgb;
     float3 halfDirection = normalize(viewDirection+lightDirection);
-
+    float3 cameraSpaceViewDir = mul((float3x3)unity_WorldToCamera, viewDirection);
     UNITY_LIGHT_ATTENUATION(attenuation,i, i.posWorld.xyz);
     float4 _MainTex_var = UNITY_SAMPLE_TEX2D(REF_MAINTEX, TRANSFORM_TEX(i.uv0, REF_MAINTEX));
     float3 Diffuse = (_MainTex_var.rgb*REF_COLOR.rgb);
@@ -37,8 +37,8 @@ float4 frag(VertexOutput i) : COLOR {
     #endif
 
     fixed _PointShadowborderBlur_var = UNITY_SAMPLE_TEX2D_SAMPLER(_PointShadowborderBlurMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _PointShadowborderBlurMask)).r * _PointShadowborderBlur;
-    float ShadowborderMin = saturate(_PointShadowborder - _PointShadowborderBlur_var/2);
-    float ShadowborderMax = saturate(_PointShadowborder + _PointShadowborderBlur_var/2);
+    float ShadowborderMin = saturate( -_PointShadowborderBlur_var*0.5 +_PointShadowborder);
+    float ShadowborderMax = saturate( _PointShadowborderBlur_var * 0.5 + _PointShadowborder);
 
     float lightContribution = dot(lightDirection, normalDirection)*attenuation;
     float directContribution = 1.0 - ((1.0 - saturate(( (saturate(lightContribution) - ShadowborderMin)) / (ShadowborderMax - ShadowborderMin))));
@@ -55,13 +55,14 @@ float4 frag(VertexOutput i) : COLOR {
     if (_ShadowCapBlendMode == 2) { // Light Shutter
         float3 normalDirectionShadowCap = normalize(mul( float3(normalLocal.r*_ShadowCapNormalMix,normalLocal.g*_ShadowCapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
         float2 transformShadowCap = float2(0,0);
+        //ここだけ他のComputeTransformCapと式が違った
         if (_UsePositionRelatedCalc) {
-            float3 transformShadowCapViewDir = mul( unity_WorldToCamera, float4(viewDirection,0) ).xyz  - float3(0,0,1);
-            float3 transformShadowCapNormal = mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz;
+            float3 transformShadowCapViewDir = cameraSpaceViewDir  - float3(0,0,1);
+            float3 transformShadowCapNormal = mul((float3x3)unity_WorldToCamera, normalDirectionShadowCap);
             float3 transformShadowCapCombined = transformShadowCapViewDir * (dot(transformShadowCapViewDir, transformShadowCapNormal) / transformShadowCapViewDir.z) + transformShadowCapNormal;
             transformShadowCap = ((transformShadowCapCombined.rg*0.5)+0.5);
         } else {
-            transformShadowCap = (mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz.rg*0.5+0.5);
+            transformShadowCap = (mul((float3x3)unity_WorldToCamera, normalDirectionShadowCap).rg*0.5+0.5);
         }
         float4 _ShadowCapTexture_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapTexture, REF_MAINTEX, TRANSFORM_TEX(transformShadowCap, _ShadowCapTexture));
         float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
@@ -121,16 +122,7 @@ float4 frag(VertexOutput i) : COLOR {
         // オプション:ShadeCap
         if (_ShadowCapBlendMode < 2) {
             float3 normalDirectionShadowCap = normalize(mul( float3(normalLocal.r*_ShadowCapNormalMix,normalLocal.g*_ShadowCapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
-            float2 transformShadowCap = float2(0,0);
-            if (_UsePositionRelatedCalc) {
-                float3 transformShadowCapViewDir = mul( unity_WorldToCamera, float4(viewDirection,0) ).xyz  - float3(0,0,1);
-                float3 transformShadowCapNormal = mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz;
-                float2 transformShadowCap_old = transformShadowCapNormal.rg*0.5+0.5;
-                float3 transformShadowCapCombined = transformShadowCapViewDir * (dot(transformShadowCapViewDir, transformShadowCapNormal) / transformShadowCapViewDir.z) + transformShadowCapNormal;
-                transformShadowCap = lerp(((transformShadowCapCombined.rg*0.5)+0.5), transformShadowCap_old, saturate(-transformShadowCapNormal.z));
-            } else {
-                transformShadowCap = (mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz.rg*0.5+0.5);
-            }
+            float2 transformShadowCap = ComputeTransformCap(cameraSpaceViewDir,normalDirectionShadowCap);
             float4 _ShadowCapTexture_var =  UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapTexture, REF_MAINTEX, TRANSFORM_TEX(transformShadowCap, _ShadowCapTexture));
             float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
             shadowcap = (1.0 - ((1.0 - (_ShadowCapTexture_var.rgb))*_ShadowCapBlendMask_var.rgb)*_ShadowCapBlend);
@@ -139,16 +131,7 @@ float4 frag(VertexOutput i) : COLOR {
         // オプション：MatCap
         if (_MatcapBlendMode < 3) {
             float3 normalDirectionMatcap = normalize(mul( float3(normalLocal.r*_MatcapNormalMix,normalLocal.g*_MatcapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
-            float2 transformMatcap = float2(0,0);
-            if (_UsePositionRelatedCalc) {
-                float3 transformMatcapViewDir = mul( unity_WorldToCamera, float4(viewDirection,0) ).xyz - float3(0,0,1);
-                float3 transformMatcapNormal = mul( unity_WorldToCamera, float4(normalDirectionMatcap,0) ).xyz;
-                float2 transformMatcap_old = transformMatcapNormal.rg*0.5+0.5;
-                float3 transformMatcapCombined = transformMatcapViewDir * (dot(transformMatcapViewDir, transformMatcapNormal) / transformMatcapViewDir.z) + transformMatcapNormal;
-                transformMatcap = lerp(((transformMatcapCombined.rg*0.5)+0.5), transformMatcap_old, saturate(-transformMatcapNormal.z));
-            } else {
-                transformMatcap = (mul( unity_WorldToCamera, float4(normalDirectionMatcap,0) ).xyz.rg*0.5+0.5);
-            }
+            float2 transformMatcap = ComputeTransformCap(cameraSpaceViewDir,normalDirectionMatcap);
             float4 _MatcapTexture_var = UNITY_SAMPLE_TEX2D_SAMPLER(_MatcapTexture, REF_MAINTEX, TRANSFORM_TEX(transformMatcap, _MatcapTexture));
             float4 _MatcapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_MatcapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _MatcapBlendMask));
             float3 matcapResult = ((_MatcapColor.rgb*_MatcapTexture_var.rgb)*_MatcapBlendMask_var.rgb*_MatcapBlend);

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeFrag.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeFrag.cginc
@@ -339,7 +339,7 @@ float4 frag(VertexOutput i) : COLOR {
     // 屈折
     #ifdef ARKTOON_REFRACTED
         float refractionValue = pow(1.0-saturate(dot(normalDirection, viewDirection)),_RefractionFresnelExp);
-        float2 sceneUVs = (i.projPos.xy / i.projPos.w) + ((refractionValue*_RefractionStrength) * mul(unity_WorldToCamera, float4(normalDirection,0) ).xyz.rgb.rg);
+        float2 sceneUVs = (i.grabUV) + ((refractionValue*_RefractionStrength) * mul(unity_WorldToCamera, float4(normalDirection,0) ).xyz.rgb.rg);
         float4 sceneColor = tex2D(_GrabTexture, sceneUVs);
     #endif
 

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeFrag.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeFrag.cginc
@@ -1,3 +1,4 @@
+
 float4 frag(VertexOutput i) : COLOR {
 
     float3x3 tangentTransform = float3x3( i.tangentDir, i.bitangentDir, i.normalDir * lerp(1, i.faceSign, _DoubleSidedFlipBackfaceNormal));
@@ -8,7 +9,7 @@ float4 frag(VertexOutput i) : COLOR {
     float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz + float3(0, +0.0000000001, 0));
     float3 lightColor = _LightColor0.rgb;
     float3 halfDirection = normalize(viewDirection+lightDirection);
-
+    float3 cameraSpaceViewDir = mul((float3x3)unity_WorldToCamera, viewDirection);
     #if !defined(SHADOWS_SCREEN)
         float attenuation = 1;
     #else
@@ -93,16 +94,7 @@ float4 frag(VertexOutput i) : COLOR {
 
     if (_ShadowCapBlendMode == 2) { // Light Shutter
         float3 normalDirectionShadowCap = normalize(mul( float3(normalLocal.r*_ShadowCapNormalMix,normalLocal.g*_ShadowCapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
-        float2 transformShadowCap = float2(0,0);
-        if (_UsePositionRelatedCalc) {
-            float3 transformShadowCapViewDir = mul( unity_WorldToCamera, float4(viewDirection,0) ).xyz - float3(0,0,1);
-            float3 transformShadowCapNormal = mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz;
-            float2 transformShadowCap_old = transformShadowCapNormal.rg*0.5+0.5;
-            float3 transformShadowCapCombined = transformShadowCapViewDir * (dot(transformShadowCapViewDir, transformShadowCapNormal) / transformShadowCapViewDir.z) + transformShadowCapNormal;
-            transformShadowCap = lerp(((transformShadowCapCombined.rg*0.5)+0.5), transformShadowCap_old, saturate(-transformShadowCapNormal.z));//saturateに置換可能なmaxだったため置き換えましたが多分この場合movが入るため高速化に繋がらないと思う・・・
-        } else {
-            transformShadowCap = (mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz.rg*0.5+0.5);
-        }
+        float2 transformShadowCap = ComputeTransformCap(cameraSpaceViewDir,normalDirectionShadowCap);
         float4 _ShadowCapTexture_var =  UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapTexture, REF_MAINTEX, TRANSFORM_TEX(transformShadowCap, _ShadowCapTexture));
         float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
         additionalContributionMultiplier *= saturate(1.0 - mad(_ShadowCapBlendMask_var.rgb,-_ShadowCapTexture_var.rgb,_ShadowCapBlendMask_var.rgb)*_ShadowCapBlend);
@@ -114,8 +106,8 @@ float4 frag(VertexOutput i) : COLOR {
     float3 coloredLight_sum = float3(0,0,0);
     if (_UseVertexLight) {
         fixed _PointShadowborderBlur_var = UNITY_SAMPLE_TEX2D_SAMPLER(_PointShadowborderBlurMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _PointShadowborderBlurMask)).r * _PointShadowborderBlur;
-        float VertexShadowborderMin = saturate(_PointShadowborder - _PointShadowborderBlur_var/2.0);
-        float VertexShadowborderMax = saturate(_PointShadowborder + _PointShadowborderBlur_var/2.0);
+        float VertexShadowborderMin = saturate(-_PointShadowborderBlur_var*0.5+_PointShadowborder);
+        float VertexShadowborderMax = saturate(_PointShadowborderBlur_var*0.5+_PointShadowborder);
         float4 directContributionVertex = 1.0 - ((1.0 - saturate(( (saturate(i.ambientAttenuation) - VertexShadowborderMin)) / (VertexShadowborderMax - VertexShadowborderMin))));
         // #ifdef USE_POINT_SHADOW_STEPS
             directContributionVertex = lerp(directContributionVertex, min(1,floor(directContributionVertex * _PointShadowSteps) / (_PointShadowSteps - 1)), _PointShadowUseStep);
@@ -265,16 +257,7 @@ float4 frag(VertexOutput i) : COLOR {
         // オプション：MatCap
         if (_MatcapBlendMode < 3) {
             float3 normalDirectionMatcap = normalize(mul( float3(normalLocal.r*_MatcapNormalMix,normalLocal.g*_MatcapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
-            float2 transformMatcap = float2(0,0);
-            if (_UsePositionRelatedCalc) {
-                float3 transformMatcapViewDir = mul( unity_WorldToCamera, float4(viewDirection,0) ).xyz - float3(0,0,1);
-                float3 transformMatcapNormal = mul( unity_WorldToCamera, float4(normalDirectionMatcap,0) ).xyz;
-                float2 transformMatcap_old = transformMatcapNormal.rg*0.5+0.5;
-                float3 transformMatcapCombined = transformMatcapViewDir * (dot(transformMatcapViewDir, transformMatcapNormal) / transformMatcapViewDir.z) + transformMatcapNormal;
-                transformMatcap = lerp(((transformMatcapCombined.rg*0.5)+0.5), transformMatcap_old, saturate(-transformMatcapNormal.z));
-            } else {
-                transformMatcap = (mul(unity_WorldToCamera, float4(normalDirectionMatcap,0) ).xyz.rg*0.5+0.5);
-            }
+            float2 transformMatcap = ComputeTransformCap(cameraSpaceViewDir,normalDirectionMatcap);
             float4 _MatcapTexture_var = UNITY_SAMPLE_TEX2D_SAMPLER(_MatcapTexture, REF_MAINTEX, TRANSFORM_TEX(transformMatcap, _MatcapTexture));
             float4 _MatcapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_MatcapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _MatcapBlendMask));
             matcap = ((_MatcapColor.rgb*_MatcapTexture_var.rgb)*_MatcapBlendMask_var.rgb*_MatcapBlend) * lerp(float3(1,1,1), finalLight,_MatcapShadeMix);
@@ -300,16 +283,7 @@ float4 frag(VertexOutput i) : COLOR {
         // オプション:ShadeCap
         if (_ShadowCapBlendMode < 2) {
             float3 normalDirectionShadowCap = normalize(mul( float3(normalLocal.r*_ShadowCapNormalMix,normalLocal.g*_ShadowCapNormalMix,normalLocal.b), tangentTransform )); // Perturbed normals
-            float2 transformShadowCap = float2(0,0);
-            if (_UsePositionRelatedCalc) {
-                float3 transformShadowCapViewDir = mul( unity_WorldToCamera, float4(viewDirection,0) ).xyz - float3(0,0,1);
-                float3 transformShadowCapNormal = mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz;
-                float2 transformShadowCap_old = transformShadowCapNormal.rg*0.5+0.5;
-                float3 transformShadowCapCombined = transformShadowCapViewDir * (dot(transformShadowCapViewDir, transformShadowCapNormal) / transformShadowCapViewDir.z) + transformShadowCapNormal;
-                transformShadowCap = lerp(((transformShadowCapCombined.rg*0.5)+0.5), transformShadowCap_old, saturate(-transformShadowCapNormal.z));
-            } else {
-                transformShadowCap = (mul( unity_WorldToCamera, float4(normalDirectionShadowCap,0) ).xyz.rg*0.5+0.5);
-            }
+            float2 transformShadowCap = ComputeTransformCap(cameraSpaceViewDir,normalDirectionShadowCap);
             float4 _ShadowCapTexture_var =  UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapTexture, REF_MAINTEX, TRANSFORM_TEX(transformShadowCap, _ShadowCapTexture));
             float4 _ShadowCapBlendMask_var = UNITY_SAMPLE_TEX2D_SAMPLER(_ShadowCapBlendMask, REF_MAINTEX, TRANSFORM_TEX(i.uv0, _ShadowCapBlendMask));
             shadowcap = (1.0 - mad(_ShadowCapBlendMask_var.rgb,-(_ShadowCapTexture_var.rgb),_ShadowCapBlendMask_var.rgb)*_ShadowCapBlend);

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeOther.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeOther.cginc
@@ -82,3 +82,24 @@ float3 GetIndirectSpecularCubemap(samplerCUBE _ReflectionCubemap, half4 _Reflect
     #endif
     return specular;
 }
+
+float2 ComputePositionRelatedTransformCap(in float3 cameraSpaceViewDir, in float3 normalDirectionCap){
+    
+   float3 transformCapViewDir = cameraSpaceViewDir - float3(0,0,1);
+   float3 transformCapNormal = mul( (float3x3)unity_WorldToCamera, normalDirectionCap );
+   float2 transformCap_old = transformCapNormal.rg*0.5+0.5;
+   float3 transformCapCombined = transformCapViewDir * (dot(transformCapViewDir, transformCapNormal) / transformCapViewDir.z) + transformCapNormal;
+   return lerp(((transformCapCombined.rg*0.5)+0.5), transformCap_old, saturate(-transformCapNormal.z));             
+}
+float2 ComputeNonPositionRelatedTransformCap(in float3 normalDirectionCap){
+    return (mul((float3x3)unity_WorldToCamera, normalDirectionCap ).rg*0.5+0.5);
+}
+
+float2 ComputeTransformCap(in float3 cameraSpaceViewDir, in float3 normalDirectionCap){
+    if(_UsePositionRelatedCalc){
+        return ComputePositionRelatedTransformCap(cameraSpaceViewDir,normalDirectionCap);
+    }
+    else{
+        return ComputeNonPositionRelatedTransformCap(normalDirectionCap);
+    }
+}

--- a/Assets/arktoon Shaders/Shaders/cginc/arkludeVertGeom.cginc
+++ b/Assets/arktoon Shaders/Shaders/cginc/arkludeVertGeom.cginc
@@ -19,7 +19,7 @@ struct v2g
         float3 lightColor3 : LIGHT_COLOR3;
     #endif
     #ifdef ARKTOON_REFRACTED
-        float4 projPos : TEXCOORD8;
+        noperspective float2 grabUV : TEXCOORD8;
     #endif
 };
 
@@ -60,8 +60,7 @@ v2g vert(appdata_full v) {
         #endif
     #endif
     #ifdef ARKTOON_REFRACTED
-        o.projPos = ComputeScreenPos (o.pos);
-        COMPUTE_EYEDEPTH(o.projPos.z);
+        o.grabUV = ComputeGrabScreenPos (o.pos).xy/o.pos.w;
     #endif
 
     return o;
@@ -91,7 +90,7 @@ struct VertexOutput {
         float4 ambientIndirect : AMBIENT_INDIRECT;
     #endif
     #ifdef ARKTOON_REFRACTED
-        float4 projPos : TEXCOORD8;
+        noperspective float2 grabUV : TEXCOORD8;
     #endif
 };
 
@@ -165,7 +164,7 @@ void geom(triangle v2g IN[3], inout TriangleStream<VertexOutput> tristream)
             #endif
 
             #ifdef ARKTOON_REFRACTED
-                o.projPos = IN[i].projPos;
+                o.grabUV = IN[i].grabUV;
             #endif
 
             #ifndef ARKTOON_ADD
@@ -218,7 +217,7 @@ void geom(triangle v2g IN[3], inout TriangleStream<VertexOutput> tristream)
             #endif
 
             #ifdef ARKTOON_REFRACTED
-                o.projPos = IN[iii].projPos;
+                o.grabUV = IN[iii].grabUV;
             #endif
 
             #ifndef ARKTOON_ADD
@@ -269,7 +268,7 @@ void geom(triangle v2g IN[3], inout TriangleStream<VertexOutput> tristream)
         #endif
 
         #ifdef ARKTOON_REFRACTED
-            o.projPos = IN[ii].projPos;
+            o.grabUV = IN[ii].grabUV;
         #endif
 
         #ifndef ARKTOON_ADD


### PR DESCRIPTION
- GrabPassで取得したテクスチャのUV参照にはComputeScreenPosではなくComputeGrabScreenPosを使うのが正しいです
- Vertexシェーダー側で先にwで除算してからnoperspective補間することでinterpolatorのサイズを削減、ピクセルシェーダーの負荷も軽減、ラスタライザの負荷も軽減